### PR TITLE
feat(pvp): batalla automática con animaciones cruzadas WAAPI

### DIFF
--- a/app/api/pvp/[id]/action/route.ts
+++ b/app/api/pvp/[id]/action/route.ts
@@ -1,16 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { z } from 'zod'
 import { getSession } from '@/lib/session'
 import { db } from '@/lib/db'
-import { resolveTurn, isPlayerTurn, getActiveSlot } from '@/lib/pvp/engine'
+import { resolveTurn, getActiveSlot } from '@/lib/pvp/engine'
 import { aiDecide } from '@/lib/pvp/ai'
-import { ABILITY_BY_ID } from '@/lib/pvp/abilities'
-import type { BattleState } from '@/lib/pvp/types'
-
-const schema = z.object({
-  abilityId: z.string(),
-  targetId:  z.string().optional(),
-})
+import type { BattleState, TurnSnapshot } from '@/lib/pvp/types'
 
 function makeRng(seed: number) {
   let s = seed
@@ -21,7 +14,7 @@ function makeRng(seed: number) {
 }
 
 export async function POST(
-  req: NextRequest,
+  _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const session = await getSession()
@@ -29,10 +22,6 @@ export async function POST(
     return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
   }
   const userId = session.user.id
-
-  let body
-  try { body = schema.parse(await req.json()) }
-  catch { return NextResponse.json({ error: 'INVALID_INPUT' }, { status: 400 }) }
 
   const { id } = await params
   const battle = await db.pvpBattle.findFirst({
@@ -44,58 +33,59 @@ export async function POST(
 
   let state: BattleState = JSON.parse(battle.state)
 
-  // Verificar que es turno del jugador
-  if (!isPlayerTurn(state)) {
-    return NextResponse.json({ error: 'NOT_YOUR_TURN' }, { status: 400 })
-  }
-
-  const actor = getActiveSlot(state)
-
-  // Validar habilidad: debe ser innata o equipada en este Therian
-  const isInnate   = body.abilityId === actor.innateAbilityId
-  const isEquipped = actor.equippedAbilities.includes(body.abilityId)
-  if (!isInnate && !isEquipped) {
-    return NextResponse.json({ error: 'ABILITY_NOT_EQUIPPED' }, { status: 400 })
-  }
-
-  // Validar cooldown
-  if ((actor.cooldowns[body.abilityId] ?? 0) > 0) {
-    return NextResponse.json({
-      error: 'ABILITY_ON_COOLDOWN',
-      turnsRemaining: actor.cooldowns[body.abilityId],
-    }, { status: 400 })
-  }
-
-  // Validar que la habilidad existe y no es pasiva
-  const ability = ABILITY_BY_ID[body.abilityId]
-  if (!ability || ability.type === 'passive') {
-    return NextResponse.json({ error: 'INVALID_ABILITY' }, { status: 400 })
+  // Si ya está completada, devolver el estado actual sin hacer nada
+  if (state.status !== 'active') {
+    return NextResponse.json({ battleId: battle.id, status: state.status, state, snapshots: [] })
   }
 
   const rng = makeRng(Date.now())
+  const snapshots: TurnSnapshot[] = []
 
-  // Resolver turno del jugador
-  const { state: s1 } = resolveTurn(state, { abilityId: body.abilityId, targetId: body.targetId }, rng)
-  state = s1
+  try {
+    let safetyCounter = 0
+    while (state.status === 'active' && safetyCounter < 100) {
+      const actorIndex = state.turnIndex
+      const actor   = getActiveSlot(state)
+      const allies  = state.slots.filter(s => s.side === actor.side)
+      const enemies = state.slots.filter(s => s.side !== actor.side)
+      const aiAction = aiDecide(actor, allies, enemies)
+      const { state: next, entry } = resolveTurn(state, aiAction, rng)
+      state = next
 
-  // Auto-resolver turnos de IA hasta el próximo turno del jugador (o fin)
-  let aiTurns = 0
-  while (state.status === 'active' && !isPlayerTurn(state) && aiTurns < 20) {
-    const aiActor  = getActiveSlot(state)
-    const allies   = state.slots.filter(s => s.side === 'defender')
-    const enemies  = state.slots.filter(s => s.side === 'attacker')
-    const aiAction = aiDecide(aiActor, allies, enemies)
-    const { state: next } = resolveTurn(state, aiAction, rng)
-    state = next
-    aiTurns++
+      // Capturar snapshot compacto: solo partes mutables por slot
+      snapshots.push({
+        actorIndex,
+        turnIndex: state.turnIndex,
+        round:     state.round,
+        slots: state.slots.map(s => ({
+          therianId:        s.therianId,
+          currentHp:        s.currentHp,
+          isDead:           s.isDead,
+          effects:          s.effects,
+          cooldowns:        s.cooldowns,
+          effectiveAgility: s.effectiveAgility,
+        })),
+        logEntry: entry,
+        status:   state.status,
+        winnerId: state.winnerId,
+      })
+
+      safetyCounter++
+    }
+  } catch (err) {
+    console.error('[pvp/action] Engine error:', err)
+    return NextResponse.json({ error: 'ENGINE_ERROR', detail: String(err) }, { status: 500 })
   }
 
-  // Determinar winnerId real (reemplazar 'attacker' por userId)
+  // Reemplazar 'attacker' por el userId real del ganador
   if (state.status === 'completed' && state.winnerId === 'attacker') {
     state.winnerId = userId
+    // Actualizar también el último snapshot
+    if (snapshots.length > 0) {
+      snapshots[snapshots.length - 1].winnerId = userId
+    }
   }
 
-  // Guardar estado actualizado
   await db.pvpBattle.update({
     where: { id: battle.id },
     data: {
@@ -109,6 +99,6 @@ export async function POST(
     battleId: battle.id,
     status:   state.status,
     state,
-    isPlayerTurn: state.status === 'active' ? isPlayerTurn(state) : false,
+    snapshots,
   })
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,6 +63,71 @@ body {
 .text-glow-epic      { text-shadow: 0 0 10px rgba(192,132,252,0.7); }
 .text-glow-legendary { text-shadow: 0 0 10px rgba(252,211,77,0.8), 0 0 20px rgba(252,211,77,0.4); }
 
+/* ─── PvP Battle animations ─────────────────────────────────────────────── */
+
+/* Atacante izquierdo (equipo del jugador) se lanza hacia la derecha */
+@keyframes pvp-attack-right {
+  0%   { transform: translateX(0)    scale(1)    rotate(0deg);  }
+  30%  { transform: translateX(68px) scale(1.12) rotate(10deg); }
+  50%  { transform: translateX(72px) scale(0.95) rotate(-6deg); }
+  70%  { transform: translateX(65px) scale(1.05) rotate(4deg);  }
+  100% { transform: translateX(0)    scale(1)    rotate(0deg);  }
+}
+
+/* Atacante derecho (rival) se lanza hacia la izquierda */
+@keyframes pvp-attack-left {
+  0%   { transform: translateX(0)     scale(1)    rotate(0deg);   }
+  30%  { transform: translateX(-68px) scale(1.12) rotate(-10deg); }
+  50%  { transform: translateX(-72px) scale(0.95) rotate(6deg);   }
+  70%  { transform: translateX(-65px) scale(1.05) rotate(-4deg);  }
+  100% { transform: translateX(0)     scale(1)    rotate(0deg);   }
+}
+
+/* Efecto de impacto: sacudida horizontal en el objetivo */
+@keyframes pvp-hit-shake {
+  0%,100% { transform: translateX(0); }
+  15%     { transform: translateX(-5px) rotate(-1.5deg); }
+  30%     { transform: translateX(5px)  rotate(1.5deg);  }
+  45%     { transform: translateX(-4px); }
+  60%     { transform: translateX(4px);  }
+  80%     { transform: translateX(-2px); }
+}
+
+/* Flash rojo en el objetivo (aplica sobre el card) */
+@keyframes pvp-hit-flash {
+  0%   { box-shadow: none; }
+  25%  { box-shadow: inset 0 0 0 2px rgba(239,68,68,0.7), 0 0 16px rgba(239,68,68,0.5); }
+  55%  { box-shadow: inset 0 0 0 1px rgba(239,68,68,0.3); }
+  100% { box-shadow: none; }
+}
+
+/* Flash verde para curaciones */
+@keyframes pvp-heal-flash {
+  0%   { box-shadow: none; }
+  25%  { box-shadow: inset 0 0 0 2px rgba(52,211,153,0.7), 0 0 16px rgba(52,211,153,0.4); }
+  55%  { box-shadow: inset 0 0 0 1px rgba(52,211,153,0.3); }
+  100% { box-shadow: none; }
+}
+
+.pvp-attack-right {
+  animation: pvp-attack-right 500ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+.pvp-attack-left {
+  animation: pvp-attack-left  500ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+.pvp-hit-shake {
+  animation: pvp-hit-shake 420ms ease-out;
+  animation-delay: 220ms;
+}
+.pvp-hit-flash {
+  animation: pvp-hit-flash 500ms ease-out;
+  animation-delay: 200ms;
+}
+.pvp-heal-flash {
+  animation: pvp-heal-flash 500ms ease-out;
+  animation-delay: 100ms;
+}
+
 /* Shimmer animation */
 @keyframes shimmer {
   0% { background-position: -200% center; }
@@ -106,4 +171,25 @@ body {
   background-clip: text;
   animation: shimmer 3s infinite;
   background-size: 200% 100%;
+}
+
+/* ─── PvP Result animations ──────────────────────────────────────────────── */
+
+@keyframes result-reveal {
+  0%   { opacity: 0; transform: scale(0.65) translateY(24px); }
+  65%  { opacity: 1; transform: scale(1.05) translateY(-5px);  }
+  100% { opacity: 1; transform: scale(1)    translateY(0);     }
+}
+.result-reveal {
+  animation: result-reveal 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) 0.55s both;
+}
+
+@keyframes icon-pop {
+  0%   { opacity: 0; transform: scale(0.1) rotate(-25deg); }
+  55%  { opacity: 1; transform: scale(1.35) rotate(8deg);  }
+  75%  { transform: scale(0.92) rotate(-3deg);              }
+  100% { opacity: 1; transform: scale(1)    rotate(0deg);   }
+}
+.icon-pop {
+  animation: icon-pop 0.65s cubic-bezier(0.34, 1.56, 0.64, 1) 0.65s both;
 }

--- a/lib/pvp/engine.ts
+++ b/lib/pvp/engine.ts
@@ -1,5 +1,5 @@
 import type {
-  TurnSlot, BattleState, ActionLogEntry, ActionResult, Aura, Archetype,
+  TurnSlot, BattleState, ActionLogEntry, ActionResult, Aura, Archetype, AvatarSnapshot,
 } from './types'
 import { FORMULAS, getTypeMultiplier } from './types'
 import { ABILITY_BY_ID, INNATE_BY_ARCHETYPE } from './abilities'
@@ -16,6 +16,7 @@ export interface InitTeamMember {
   instinct:   number
   charisma:   number
   equippedAbilities: string[]  // IDs equipadas (max 4)
+  avatarSnapshot?: AvatarSnapshot
 }
 
 export function initBattleState(
@@ -80,6 +81,7 @@ function buildSlot(m: InitTeamMember, side: 'attacker' | 'defender'): TurnSlot {
     cooldowns:        {},
     effects:          [],
     isDead:           false,
+    avatarSnapshot:   m.avatarSnapshot,
   }
 }
 

--- a/lib/pvp/types.ts
+++ b/lib/pvp/types.ts
@@ -54,6 +54,18 @@ export interface ActiveEffect {
   turnsRemaining: number
 }
 
+export interface AvatarSnapshot {
+  appearance: {
+    palette: string
+    paletteColors: { primary: string; secondary: string; accent: string }
+    eyes: string
+    pattern: string
+    signature: string
+  }
+  level: number
+  rarity: string
+}
+
 export interface TurnSlot {
   therianId:         string
   side:              'attacker' | 'defender'
@@ -70,6 +82,7 @@ export interface TurnSlot {
   cooldowns:         Record<string, number>  // abilityId → turnos restantes
   effects:           ActiveEffect[]
   isDead:            boolean
+  avatarSnapshot?:   AvatarSnapshot
 }
 
 export interface ActionLogEntry {
@@ -109,6 +122,28 @@ export interface BattleState {
   log:        ActionLogEntry[]
   status:     'active' | 'completed'
   winnerId:   string | null  // userId del ganador, o null si ganó el defensor
+}
+
+// ─── Snapshot por turno (para animación cliente) ──────────────────────────────
+
+/** Estado mínimo y mutable capturado después de cada turno resuelto */
+export interface SlotSnapshot {
+  therianId:        string
+  currentHp:        number
+  isDead:           boolean
+  effects:          ActiveEffect[]
+  cooldowns:        Record<string, number>
+  effectiveAgility: number
+}
+
+export interface TurnSnapshot {
+  actorIndex: number           // índice del slot que actuó este turno
+  turnIndex:  number           // índice del próximo en actuar
+  round:      number
+  slots:      SlotSnapshot[]
+  logEntry:   ActionLogEntry
+  status:     'active' | 'completed'
+  winnerId:   string | null
 }
 
 // ─── IA ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Auto-batalla**: elimina el input del jugador — ambos equipos son controlados por IA usando los mismos criterios de `aiDecide`. El servidor resuelve la batalla completa en un solo `POST /api/pvp/[id]/action` y devuelve un array de `TurnSnapshot[]` para reproducción.
- **Animación paso a paso**: el cliente reproduce los turnos con delays configurables (1×/2×/4×) y botón Skip. La barra de progreso y el contador de turno reflejan el estado en tiempo real.
- **Movimiento cruzado real (WAAPI)**: los avatares vuelan hacia el slot objetivo usando `getBoundingClientRect()` para calcular el vector exacto `(dx, dy)`. Si el slot atacante está en la fila superior-izquierda y el objetivo en la fila inferior-derecha, el avatar cruza la arena en diagonal.
- **Indicadores visuales claros**: flash blanco en la card atacante al inicio del turno, flash rojo/verde + shake horizontal sincronizados con la llegada del avatar (al 46% de la duración de la animación).
- **Z-index durante el cruce**: la card atacante sube a `z-index: 50` durante el vuelo para aparecer por encima de todas las demás.
- **Pantalla de resultado animada**: `result-reveal` (spring bounce) + `icon-pop` encadenado con delay, con gradientes dorado (victoria) o rojo (derrota).
- **`AvatarSnapshot` embebido en `TurnSlot`**: datos de apariencia almacenados en el estado de batalla para renderizar `TherianAvatar` sin fetch adicional.

## Test plan

- [ ] Iniciar batalla PvP → verificar que ambos equipos actúan automáticamente
- [ ] Confirmar que los avatares vuelan hacia el slot correcto (no solo de frente)
- [ ] Verificar flash blanco en atacante + flash rojo en objetivo + shake
- [ ] Probar velocidades 1×, 2×, 4× y Skip
- [ ] Confirmar pantalla de resultado con animación al finalizar la batalla
- [ ] Verificar que el movimiento cruza columnas (atacante izquierdo → defensor derecho) sin clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)