### PR TITLE
feat: libro de hechizos, inventario de habilidades, PvP modo manual y fixes

### DIFF
--- a/app/(game)/spellbook/page.tsx
+++ b/app/(game)/spellbook/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation'
+import { getSession } from '@/lib/session'
+import SpellbookPage from '@/components/spellbook/SpellbookPage'
+
+export const metadata = { title: 'Libro de Hechizos — Therian' }
+
+export default async function SpellbookRoute() {
+  const session = await getSession()
+  if (!session?.user?.id) redirect('/login')
+
+  return <SpellbookPage />
+}

--- a/app/api/inventory/route.ts
+++ b/app/api/inventory/route.ts
@@ -3,6 +3,7 @@ import { getSession } from '@/lib/session'
 import { db } from '@/lib/db'
 import { EGG_BY_ID } from '@/lib/items/eggs'
 import { SHOP_ITEMS } from '@/lib/shop/catalog'
+import { getRuneById } from '@/lib/catalogs/runes'
 
 export type InventoryItemDTO = {
   id: string
@@ -117,5 +118,25 @@ export async function GET() {
     }
   })
 
-  return NextResponse.json({ items: enriched })
+  // Fetch user-level rune inventory (earned from PvP weekly/monthly rewards)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dba = db as any
+  const userRunes = await dba.userRuneInventory.findMany({
+    where: { userId, quantity: { gt: 0 } },
+    orderBy: { runeId: 'asc' },
+  }) as Array<{ runeId: string; quantity: number; source: string }>
+
+  const userRuneDTOs = userRunes.map(r => {
+    const rune = getRuneById(r.runeId)
+    return {
+      runeId: r.runeId,
+      quantity: r.quantity,
+      source: r.source,
+      name: rune?.name ?? r.runeId,
+      tier: rune?.tier ?? 1,
+      mod: rune?.mod ?? {},
+    }
+  })
+
+  return NextResponse.json({ items: enriched, userRunes: userRuneDTOs })
 }

--- a/app/api/pvp/[id]/action/route.ts
+++ b/app/api/pvp/[id]/action/route.ts
@@ -4,6 +4,14 @@ import { db } from '@/lib/db'
 import { resolveTurn, getActiveSlot } from '@/lib/pvp/engine'
 import { aiDecide } from '@/lib/pvp/ai'
 import type { BattleState, TurnSnapshot } from '@/lib/pvp/types'
+import {
+  applyMmrChange,
+  getRankFromMmr,
+  getGoldRewardByRank,
+  needsWeeklyReset,
+} from '@/lib/pvp/mmr'
+
+const PVP_XP_PER_THERIAN = 30
 
 function makeRng(seed: number) {
   let s = seed
@@ -11,6 +19,10 @@ function makeRng(seed: number) {
     s = (s * 1664525 + 1013904223) >>> 0
     return s / 0xFFFFFFFF
   }
+}
+
+function xpToNextLevel(level: number): number {
+  return Math.floor(100 * Math.pow(1.5, level - 1))
 }
 
 export async function POST(
@@ -88,6 +100,102 @@ export async function POST(
     }
   }
 
+  // --- Recompensas al completar la batalla ---
+  let mmrDelta = 0
+  let newMmr = 1000
+  let rank = 'BRONCE'
+  let goldEarned = 0
+  let weeklyPvpWins = 0
+
+  if (state.status === 'completed') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dba = db as any
+    const user = await dba.user.findUnique({
+      where: { id: userId },
+      select: {
+        mmr: true,
+        peakMmr: true,
+        weeklyPvpWins: true,
+        weeklyPvpResetAt: true,
+        level: true,
+        xp: true,
+      },
+    }) as {
+      mmr: number
+      peakMmr: number
+      weeklyPvpWins: number
+      weeklyPvpResetAt: Date | null
+      level: number
+      xp: number
+    } | null
+
+    if (user) {
+      const won = state.winnerId === userId
+      const mmrChange = applyMmrChange(user.mmr, won)
+      newMmr = mmrChange.newMmr
+      mmrDelta = mmrChange.delta
+      rank = getRankFromMmr(newMmr)
+      goldEarned = won ? getGoldRewardByRank(rank as Parameters<typeof getGoldRewardByRank>[0]) : 0
+
+      // Lazy weekly reset
+      const resetNeeded = needsWeeklyReset(user.weeklyPvpResetAt)
+      const currentWeeklyWins = resetNeeded ? 0 : user.weeklyPvpWins
+      weeklyPvpWins = won ? currentWeeklyWins + 1 : currentWeeklyWins
+
+      const newPeakMmr = Math.max(user.peakMmr, newMmr)
+
+      // XP de cuenta por los Therians del equipo atacante (solo si ganó)
+      let userNewXp = user.xp
+      let userNewLevel = user.level
+      if (won) {
+        const attackerTeamIds: string[] = JSON.parse(battle.attackerTeam)
+        const xpGained = PVP_XP_PER_THERIAN * attackerTeamIds.length
+        userNewXp = user.xp + xpGained
+        while (userNewXp >= xpToNextLevel(userNewLevel)) {
+          userNewXp -= xpToNextLevel(userNewLevel)
+          userNewLevel += 1
+        }
+      }
+
+      const userUpdateData: Record<string, unknown> = {
+        mmr: newMmr,
+        peakMmr: newPeakMmr,
+        weeklyPvpWins,
+        ...(resetNeeded ? { weeklyPvpResetAt: new Date() } : {}),
+        ...(won && goldEarned > 0 ? { gold: { increment: goldEarned } } : {}),
+        ...(won ? { xp: userNewXp, level: userNewLevel } : {}),
+      }
+
+      await dba.$transaction([
+        dba.pvpBattle.update({
+          where: { id: battle.id },
+          data: {
+            state:    JSON.stringify(state),
+            status:   state.status,
+            winnerId: state.status === 'completed' ? (state.winnerId ?? null) : undefined,
+          },
+        }),
+        dba.user.update({
+          where: { id: userId },
+          data: userUpdateData,
+        }),
+      ])
+
+      return NextResponse.json({
+        battleId: battle.id,
+        status:   state.status,
+        state,
+        snapshots,
+        mmrDelta,
+        newMmr,
+        rank,
+        goldEarned,
+        weeklyPvpWins,
+      })
+    }
+  }
+
+  // Batalla aún activa o sin usuario (fallback sin rewards)
   await db.pvpBattle.update({
     where: { id: battle.id },
     data: {

--- a/app/api/pvp/[id]/switch-frontliner/route.ts
+++ b/app/api/pvp/[id]/switch-frontliner/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getSession } from '@/lib/session'
+import { db } from '@/lib/db'
+import { applyFrontlinerSwitch, advanceTurn } from '@/lib/pvp/engine'
+import type { BattleState } from '@/lib/pvp/types'
+
+const schema = z.object({
+  therianId: z.string(),
+})
+
+const SWITCH_COOLDOWN_MS = 10_000
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  }
+  const userId = session.user.id
+
+  const { id } = await params
+  const battle = await db.pvpBattle.findFirst({
+    where: { id, attackerId: userId, status: 'active' },
+  })
+  if (!battle) {
+    return NextResponse.json({ error: 'NOT_FOUND' }, { status: 404 })
+  }
+
+  let state: BattleState = JSON.parse(battle.state)
+
+  if (state.status !== 'active') {
+    return NextResponse.json({ error: 'BATTLE_NOT_ACTIVE' }, { status: 400 })
+  }
+  if (state.mode !== 'manual') {
+    return NextResponse.json({ error: 'NOT_MANUAL_MODE' }, { status: 400 })
+  }
+
+  // Only allow switch when in active phase OR waiting_attacker_switch
+  const allowedPhases = ['active', 'waiting_attacker_switch'] as const
+  if (!allowedPhases.includes(state.phase as typeof allowedPhases[number])) {
+    return NextResponse.json({ error: 'SWITCH_NOT_ALLOWED', phase: state.phase }, { status: 400 })
+  }
+
+  // Check cooldown (only for voluntary switches, not for forced switches on death)
+  const isForced = state.phase === 'waiting_attacker_switch'
+  if (!isForced && state.switchCooldownEnd && Date.now() < state.switchCooldownEnd) {
+    const remainingMs = state.switchCooldownEnd - Date.now()
+    return NextResponse.json({ error: 'SWITCH_COOLDOWN', remainingMs }, { status: 429 })
+  }
+
+  let body
+  try { body = schema.parse(await req.json()) }
+  catch { return NextResponse.json({ error: 'INVALID_INPUT' }, { status: 400 }) }
+
+  const { therianId } = body
+
+  // Validate: must be an alive attacker slot that is not the current frontliner
+  const slot = state.slots.find(s => s.therianId === therianId && s.side === 'attacker' && !s.isDead)
+  if (!slot) {
+    return NextResponse.json({ error: 'INVALID_TARGET' }, { status: 400 })
+  }
+  if (state.frontliner?.attacker === therianId) {
+    return NextResponse.json({ error: 'ALREADY_FRONTLINER' }, { status: 400 })
+  }
+
+  const outId = state.frontliner?.attacker ?? null
+  applyFrontlinerSwitch(state, 'attacker', therianId)
+  state.phase = 'active'
+
+  // Set cooldown only for voluntary switches
+  if (!isForced) {
+    state.switchCooldownEnd = Date.now() + SWITCH_COOLDOWN_MS
+  }
+
+  // After the switch, if it was a forced switch, advance the turn to continue battle
+  if (isForced) {
+    advanceTurn(state)
+  }
+
+  await db.pvpBattle.update({
+    where: { id: battle.id },
+    data: {
+      state:  JSON.stringify(state),
+      status: state.status,
+    },
+  })
+
+  return NextResponse.json({
+    battleId:           battle.id,
+    status:             state.status,
+    state,
+    switchCooldownEnd:  state.switchCooldownEnd ?? null,
+    switchEvent: outId ? { side: 'attacker', outId, inId: therianId } : undefined,
+    phase:              state.phase,
+  })
+}

--- a/app/api/pvp/[id]/turn/route.ts
+++ b/app/api/pvp/[id]/turn/route.ts
@@ -1,0 +1,303 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getSession } from '@/lib/session'
+import { db } from '@/lib/db'
+import { resolveTurn, getActiveSlot, applyFrontlinerSwitch, advanceTurn } from '@/lib/pvp/engine'
+import { aiDecide, aiDecideSwitch } from '@/lib/pvp/ai'
+import type { BattleState, TurnSnapshot } from '@/lib/pvp/types'
+import {
+  applyMmrChange,
+  getRankFromMmr,
+  getGoldRewardByRank,
+  needsWeeklyReset,
+} from '@/lib/pvp/mmr'
+
+const PVP_XP_PER_THERIAN = 30
+
+function xpToNextLevel(level: number): number {
+  return Math.floor(100 * Math.pow(1.5, level - 1))
+}
+
+const schema = z.object({
+  abilityId: z.string(),
+  targetId:  z.string().optional(),
+})
+
+function makeRng(seed: number) {
+  let s = seed
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0
+    return s / 0xFFFFFFFF
+  }
+}
+
+function makeSlotSnapshot(s: BattleState['slots'][0]) {
+  return {
+    therianId:        s.therianId,
+    currentHp:        s.currentHp,
+    maxHp:            s.maxHp,
+    shieldHp:         s.shieldHp,
+    isDead:           s.isDead,
+    effects:          s.effects,
+    cooldowns:        s.cooldowns,
+    effectiveAgility: s.effectiveAgility,
+  }
+}
+
+function makeSwitchSnapshot(
+  state: BattleState,
+  side: 'attacker' | 'defender',
+  outId: string,
+  inId: string,
+  inName: string | null,
+): TurnSnapshot {
+  return {
+    actorIndex:  state.turnIndex,
+    turnIndex:   state.turnIndex,
+    round:       state.round,
+    slots:       state.slots.map(makeSlotSnapshot),
+    logEntry: {
+      turn:        state.round,
+      actorId:     inId,
+      actorName:   inName,
+      abilityId:   'switch',
+      abilityName: 'Cambio de Therian',
+      targetIds:   [],
+      results:     [],
+    },
+    status:      state.status,
+    winnerId:    state.winnerId,
+    switchEvent: { side, outId, inId },
+    frontliner:  state.frontliner ? { ...state.frontliner } : undefined,
+    phase:       state.phase,
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  }
+  const userId = session.user.id
+
+  const { id } = await params
+  const battle = await db.pvpBattle.findFirst({
+    where: { id, attackerId: userId, status: 'active' },
+  })
+  if (!battle) {
+    return NextResponse.json({ error: 'NOT_FOUND' }, { status: 404 })
+  }
+
+  let state: BattleState = JSON.parse(battle.state)
+
+  if (state.status !== 'active') {
+    return NextResponse.json({ error: 'BATTLE_NOT_ACTIVE' }, { status: 400 })
+  }
+  if (state.mode !== 'manual') {
+    return NextResponse.json({ error: 'NOT_MANUAL_MODE' }, { status: 400 })
+  }
+
+  // Must be player's turn
+  if (state.phase === 'waiting_attacker_switch') {
+    return NextResponse.json({ error: 'WAITING_SWITCH', phase: state.phase }, { status: 400 })
+  }
+  if (state.phase === 'waiting_defender_switch') {
+    // AI handles defender switch automatically before player acts
+    return NextResponse.json({ error: 'WAITING_SWITCH', phase: state.phase }, { status: 400 })
+  }
+
+  const currentActor = getActiveSlot(state)
+  if (currentActor.side !== 'attacker') {
+    return NextResponse.json({ error: 'NOT_YOUR_TURN' }, { status: 400 })
+  }
+
+  let body
+  try { body = schema.parse(await req.json()) }
+  catch { return NextResponse.json({ error: 'INVALID_INPUT' }, { status: 400 }) }
+
+  // Validate the ability belongs to the player's frontliner
+  const frontliners = state.frontliner
+  if (frontliners) {
+    const myFrontliner = state.slots.find(s => s.therianId === frontliners.attacker)
+    if (!myFrontliner) {
+      return NextResponse.json({ error: 'FRONTLINER_NOT_FOUND' }, { status: 400 })
+    }
+    const validAbilities = [...myFrontliner.equippedAbilities, myFrontliner.innateAbilityId]
+    if (!validAbilities.includes(body.abilityId)) {
+      return NextResponse.json({ error: 'INVALID_ABILITY' }, { status: 400 })
+    }
+  }
+
+  const rng = makeRng(Date.now())
+  const snapshots: TurnSnapshot[] = []
+
+  try {
+    // ── Player's turn ────────────────────────────────────────────────────────
+    const playerActorIndex = state.turnIndex
+    const { state: afterPlayer, entry: playerEntry } = resolveTurn(
+      state,
+      { abilityId: body.abilityId, targetId: body.targetId },
+      rng,
+    )
+    state = afterPlayer
+
+    snapshots.push({
+      actorIndex:  playerActorIndex,
+      turnIndex:   state.turnIndex,
+      round:       state.round,
+      slots:       state.slots.map(makeSlotSnapshot),
+      logEntry:    playerEntry,
+      status:      state.status,
+      winnerId:    state.winnerId,
+      frontliner:  state.frontliner ? { ...state.frontliner } : undefined,
+      phase:       state.phase,
+    })
+
+    // Handle if defender frontliner died from player's attack
+    if (state.status === 'active' && state.phase === 'waiting_defender_switch') {
+      const outId = state.frontliner!.defender
+      let newId = aiDecideSwitch(state, 'defender')
+      if (!newId) {
+        const firstAlive = state.slots.find(s => s.side === 'defender' && !s.isDead)
+        newId = firstAlive?.therianId ?? null
+      }
+      if (newId) {
+        const inSlot = state.slots.find(s => s.therianId === newId)
+        applyFrontlinerSwitch(state, 'defender', newId)
+        state.phase = 'active'
+        advanceTurn(state)
+        snapshots.push(makeSwitchSnapshot(state, 'defender', outId, newId, inSlot?.name ?? null))
+      }
+    }
+
+    // ── AI's turn (if battle still active and it's AI's turn) ────────────────
+    if (state.status === 'active' && state.phase === 'active') {
+      // Check if AI should proactively switch before acting
+      if (state.frontliner) {
+        const defenderSwitchId = aiDecideSwitch(state, 'defender')
+        if (defenderSwitchId) {
+          const outId = state.frontliner.defender
+          const inSlot = state.slots.find(s => s.therianId === defenderSwitchId)
+          applyFrontlinerSwitch(state, 'defender', defenderSwitchId)
+          snapshots.push(makeSwitchSnapshot(state, 'defender', outId, defenderSwitchId, inSlot?.name ?? null))
+        }
+      }
+
+      // AI acts
+      if (state.status === 'active') {
+        const aiActorIndex = state.turnIndex
+        const aiActor  = getActiveSlot(state)
+        const aiAllies = state.slots.filter(s => s.side === aiActor.side)
+        const aiEnemies = state.slots.filter(s => s.side !== aiActor.side)
+        const aiAction = aiDecide(aiActor, aiAllies, aiEnemies)
+        const { state: afterAI, entry: aiEntry } = resolveTurn(state, aiAction, rng)
+        state = afterAI
+
+        snapshots.push({
+          actorIndex:  aiActorIndex,
+          turnIndex:   state.turnIndex,
+          round:       state.round,
+          slots:       state.slots.map(makeSlotSnapshot),
+          logEntry:    aiEntry,
+          status:      state.status,
+          winnerId:    state.winnerId,
+          frontliner:  state.frontliner ? { ...state.frontliner } : undefined,
+          phase:       state.phase,
+        })
+
+        // Handle if attacker frontliner died from AI's attack
+        if (state.status === 'active' && state.phase === 'waiting_attacker_switch') {
+          // Player must switch — leave phase as-is, client shows switch UI
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[pvp/turn] Engine error:', err)
+    return NextResponse.json({ error: 'ENGINE_ERROR', detail: String(err) }, { status: 500 })
+  }
+
+  // Resolve winner alias
+  if (state.status === 'completed' && state.winnerId === 'attacker') {
+    state.winnerId = userId
+    if (snapshots.length > 0) {
+      snapshots[snapshots.length - 1].winnerId = userId
+    }
+  }
+
+  // ── Rewards on completion ────────────────────────────────────────────────
+  let mmrDelta = 0, newMmr = 1000, rank = 'BRONCE', goldEarned = 0, weeklyPvpWins = 0
+
+  if (state.status === 'completed') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dba = db as any
+    const user = await dba.user.findUnique({
+      where: { id: userId },
+      select: { mmr: true, peakMmr: true, weeklyPvpWins: true, weeklyPvpResetAt: true, level: true, xp: true },
+    }) as { mmr: number; peakMmr: number; weeklyPvpWins: number; weeklyPvpResetAt: Date | null; level: number; xp: number } | null
+
+    if (user) {
+      const won        = state.winnerId === userId
+      const mmrChange  = applyMmrChange(user.mmr, won)
+      newMmr           = mmrChange.newMmr
+      mmrDelta         = mmrChange.delta
+      rank             = getRankFromMmr(newMmr)
+      goldEarned       = won ? getGoldRewardByRank(rank as Parameters<typeof getGoldRewardByRank>[0]) : 0
+
+      const resetNeeded       = needsWeeklyReset(user.weeklyPvpResetAt)
+      const currentWeeklyWins = resetNeeded ? 0 : user.weeklyPvpWins
+      weeklyPvpWins           = won ? currentWeeklyWins + 1 : currentWeeklyWins
+
+      const newPeakMmr = Math.max(user.peakMmr, newMmr)
+
+      let userNewXp = user.xp, userNewLevel = user.level
+      if (won) {
+        const attackerTeamIds: string[] = JSON.parse(battle.attackerTeam)
+        userNewXp = user.xp + PVP_XP_PER_THERIAN * attackerTeamIds.length
+        while (userNewXp >= xpToNextLevel(userNewLevel)) {
+          userNewXp -= xpToNextLevel(userNewLevel)
+          userNewLevel++
+        }
+      }
+
+      const userUpdateData: Record<string, unknown> = {
+        mmr: newMmr, peakMmr: newPeakMmr, weeklyPvpWins,
+        ...(resetNeeded ? { weeklyPvpResetAt: new Date() } : {}),
+        ...(won && goldEarned > 0 ? { gold: { increment: goldEarned } } : {}),
+        ...(won ? { xp: userNewXp, level: userNewLevel } : {}),
+      }
+
+      await dba.$transaction([
+        dba.pvpBattle.update({
+          where: { id: battle.id },
+          data: { state: JSON.stringify(state), status: state.status, winnerId: state.winnerId ?? null },
+        }),
+        dba.user.update({ where: { id: userId }, data: userUpdateData }),
+      ])
+
+      return NextResponse.json({
+        battleId: battle.id, status: state.status, state, snapshots, phase: state.phase,
+        mmrDelta, newMmr, rank, goldEarned, weeklyPvpWins,
+      })
+    }
+  }
+
+  await db.pvpBattle.update({
+    where: { id: battle.id },
+    data: {
+      state:    JSON.stringify(state),
+      status:   state.status,
+      winnerId: state.status === 'completed' ? (state.winnerId ?? null) : undefined,
+    },
+  })
+
+  return NextResponse.json({
+    battleId: battle.id,
+    status:   state.status,
+    state,
+    snapshots,
+    phase:    state.phase,
+  })
+}

--- a/app/api/pvp/ranking/route.ts
+++ b/app/api/pvp/ranking/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import { db } from '@/lib/db'
+import { getRankFromMmr } from '@/lib/pvp/mmr'
+
+export async function GET() {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dba = db as any
+
+  const top10 = await dba.user.findMany({
+    orderBy: { mmr: 'desc' },
+    take: 10,
+    select: { id: true, name: true, mmr: true },
+  }) as Array<{ id: string; name: string | null; mmr: number }>
+
+  const entries = top10.map((u, i) => ({
+    position: i + 1,
+    name: u.name ?? 'Anónimo',
+    mmr: u.mmr,
+    rank: getRankFromMmr(u.mmr),
+    isCurrentUser: u.id === session.user.id,
+  }))
+
+  // If current user is not in top 10, find their position
+  const isInTop10 = entries.some(e => e.isCurrentUser)
+  let currentUserEntry = null
+  if (!isInTop10) {
+    const me = await dba.user.findUnique({
+      where: { id: session.user.id },
+      select: { name: true, mmr: true },
+    }) as { name: string | null; mmr: number } | null
+
+    if (me) {
+      const above = await dba.user.count({ where: { mmr: { gt: me.mmr } } })
+      currentUserEntry = {
+        position: above + 1,
+        name: me.name ?? 'Tú',
+        mmr: me.mmr,
+        rank: getRankFromMmr(me.mmr),
+        isCurrentUser: true,
+      }
+    }
+  }
+
+  return NextResponse.json({ entries, currentUser: currentUserEntry })
+}

--- a/app/api/pvp/rewards/monthly/route.ts
+++ b/app/api/pvp/rewards/monthly/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import { db } from '@/lib/db'
+import {
+  getRankFromMmr,
+  currentMonthKey,
+  MONTHLY_REWARDS,
+} from '@/lib/pvp/mmr'
+import { randomUUID } from 'crypto'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Dba = any
+
+async function getUserMonthlyState(userId: string, dba: Dba) {
+  const user = await dba.user.findUnique({
+    where: { id: userId },
+    select: {
+      mmr: true,
+      peakMmr: true,
+      lastMonthlyRewardMonth: true,
+    },
+  }) as {
+    mmr: number
+    peakMmr: number
+    lastMonthlyRewardMonth: string | null
+  } | null
+  return user
+}
+
+export async function GET() {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dba = db as any
+  const user = await getUserMonthlyState(session.user.id, dba)
+  if (!user) return NextResponse.json({ error: 'USER_NOT_FOUND' }, { status: 404 })
+
+  const month = currentMonthKey()
+  const peakRank = getRankFromMmr(user.peakMmr)
+  const reward = MONTHLY_REWARDS[peakRank]
+  const alreadyClaimed = user.lastMonthlyRewardMonth === month
+
+  return NextResponse.json({
+    peakMmr: user.peakMmr,
+    peakRank,
+    currentMonth: month,
+    alreadyClaimed,
+    hasReward: reward !== null && !alreadyClaimed,
+    reward,
+  })
+}
+
+export async function POST() {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dba = db as any
+  const user = await getUserMonthlyState(session.user.id, dba)
+  if (!user) return NextResponse.json({ error: 'USER_NOT_FOUND' }, { status: 404 })
+
+  const month = currentMonthKey()
+
+  if (user.lastMonthlyRewardMonth === month) {
+    return NextResponse.json({ error: 'ALREADY_CLAIMED' }, { status: 409 })
+  }
+
+  const peakRank = getRankFromMmr(user.peakMmr)
+  const reward = MONTHLY_REWARDS[peakRank]
+
+  if (!reward) {
+    return NextResponse.json({ error: 'NO_REWARD_FOR_RANK', rank: peakRank }, { status: 400 })
+  }
+
+  // Accesorios: cada accesorio se crea como instancia única (igual que en shop/buy)
+  const accessoryItems = reward.accessories.map(accessoryId => {
+    const instanceId = `${accessoryId}:${randomUUID()}`
+    return dba.inventoryItem.create({
+      data: { userId: session.user.id, type: 'ACCESSORY', itemId: instanceId, quantity: 1 },
+    })
+  })
+
+  // Huevos: upsert por itemId
+  const eggItems = reward.eggs.map(eggId =>
+    dba.inventoryItem.upsert({
+      where: { userId_itemId: { userId: session.user.id, itemId: eggId } },
+      update: { quantity: { increment: 1 } },
+      create: { userId: session.user.id, type: 'EGG', itemId: eggId, quantity: 1 },
+    })
+  )
+
+  // Runas al UserRuneInventory — agrupar por runeId en caso de duplicados en la lista
+  const runeCountMap: Record<string, number> = {}
+  for (const runeId of reward.runes) {
+    runeCountMap[runeId] = (runeCountMap[runeId] ?? 0) + 1
+  }
+  const runeItems = Object.entries(runeCountMap).map(([runeId, qty]) =>
+    dba.userRuneInventory.upsert({
+      where: { userId_runeId: { userId: session.user.id, runeId } },
+      update: { quantity: { increment: qty } },
+      create: { userId: session.user.id, runeId, quantity: qty, source: 'monthly' },
+    })
+  )
+
+  await dba.$transaction([
+    // Gold + essence + reset peakMmr al mmr actual + marcar mes cobrado
+    dba.user.update({
+      where: { id: session.user.id },
+      data: {
+        gold: { increment: reward.gold },
+        essence: { increment: reward.essence },
+        peakMmr: user.mmr, // resetear pico al mmr actual del nuevo mes
+        lastMonthlyRewardMonth: month,
+      },
+    }),
+    ...eggItems,
+    ...accessoryItems,
+    ...runeItems,
+  ])
+
+  return NextResponse.json({
+    claimed: true,
+    rank: peakRank,
+    reward,
+  })
+}

--- a/app/api/pvp/rewards/weekly/route.ts
+++ b/app/api/pvp/rewards/weekly/route.ts
@@ -1,0 +1,132 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import { db } from '@/lib/db'
+import {
+  WEEKLY_WINS_REQUIRED,
+  WEEKLY_CHEST_GOLD,
+  WEEKLY_CHEST_EGG,
+  WEEKLY_CHEST_RUNE_POOL,
+  WEEKLY_CHEST_RUNE_COUNT,
+  needsWeeklyReset,
+  pickRandom,
+} from '@/lib/pvp/mmr'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Dba = any
+
+async function getUserRewardState(userId: string, dba: Dba) {
+  const user = await dba.user.findUnique({
+    where: { id: userId },
+    select: {
+      weeklyPvpWins: true,
+      weeklyPvpResetAt: true,
+      lastWeeklyChestAt: true,
+    },
+  }) as {
+    weeklyPvpWins: number
+    weeklyPvpResetAt: Date | null
+    lastWeeklyChestAt: Date | null
+  } | null
+  return user
+}
+
+export async function GET() {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dba = db as any
+  const user = await getUserRewardState(session.user.id, dba)
+  if (!user) return NextResponse.json({ error: 'USER_NOT_FOUND' }, { status: 404 })
+
+  const resetNeeded = needsWeeklyReset(user.weeklyPvpResetAt)
+  const effectiveWins = resetNeeded ? 0 : user.weeklyPvpWins
+
+  // El cofre está disponible si llegó a 15 victorias Y no lo reclamó en el período actual
+  const chestEligible = effectiveWins >= WEEKLY_WINS_REQUIRED
+  const alreadyClaimed = !resetNeeded &&
+    user.lastWeeklyChestAt !== null &&
+    user.weeklyPvpResetAt !== null &&
+    user.lastWeeklyChestAt >= user.weeklyPvpResetAt
+
+  const chestAvailable = chestEligible && !alreadyClaimed
+
+  return NextResponse.json({
+    weeklyPvpWins: effectiveWins,
+    required: WEEKLY_WINS_REQUIRED,
+    chestAvailable,
+    alreadyClaimed,
+    weekResetAt: resetNeeded ? null : user.weeklyPvpResetAt?.toISOString() ?? null,
+    preview: {
+      gold: WEEKLY_CHEST_GOLD,
+      egg: WEEKLY_CHEST_EGG,
+      runes: WEEKLY_CHEST_RUNE_COUNT,
+    },
+  })
+}
+
+export async function POST() {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dba = db as any
+  const user = await getUserRewardState(session.user.id, dba)
+  if (!user) return NextResponse.json({ error: 'USER_NOT_FOUND' }, { status: 404 })
+
+  const resetNeeded = needsWeeklyReset(user.weeklyPvpResetAt)
+  const effectiveWins = resetNeeded ? 0 : user.weeklyPvpWins
+
+  if (effectiveWins < WEEKLY_WINS_REQUIRED) {
+    return NextResponse.json({ error: 'NOT_ENOUGH_WINS', current: effectiveWins, required: WEEKLY_WINS_REQUIRED }, { status: 400 })
+  }
+
+  const alreadyClaimed = !resetNeeded &&
+    user.lastWeeklyChestAt !== null &&
+    user.weeklyPvpResetAt !== null &&
+    user.lastWeeklyChestAt >= user.weeklyPvpResetAt
+
+  if (alreadyClaimed) {
+    return NextResponse.json({ error: 'ALREADY_CLAIMED' }, { status: 409 })
+  }
+
+  // Seleccionar 2 runas aleatorias del pool T1
+  const runesAwarded = pickRandom(WEEKLY_CHEST_RUNE_POOL, WEEKLY_CHEST_RUNE_COUNT)
+
+  const now = new Date()
+
+  await dba.$transaction([
+    // +800 gold + lastWeeklyChestAt
+    dba.user.update({
+      where: { id: session.user.id },
+      data: {
+        gold: { increment: WEEKLY_CHEST_GOLD },
+        lastWeeklyChestAt: now,
+      },
+    }),
+    // Egg al inventario
+    dba.inventoryItem.upsert({
+      where: { userId_itemId: { userId: session.user.id, itemId: WEEKLY_CHEST_EGG } },
+      update: { quantity: { increment: 1 } },
+      create: { userId: session.user.id, type: 'EGG', itemId: WEEKLY_CHEST_EGG, quantity: 1 },
+    }),
+    // Runas al inventario de usuario
+    ...runesAwarded.map(runeId =>
+      dba.userRuneInventory.upsert({
+        where: { userId_runeId: { userId: session.user.id, runeId } },
+        update: { quantity: { increment: 1 } },
+        create: { userId: session.user.id, runeId, quantity: 1, source: 'weekly' },
+      })
+    ),
+  ])
+
+  return NextResponse.json({
+    gold: WEEKLY_CHEST_GOLD,
+    egg: WEEKLY_CHEST_EGG,
+    runes: runesAwarded,
+  })
+}

--- a/app/api/pvp/start/route.ts
+++ b/app/api/pvp/start/route.ts
@@ -9,6 +9,7 @@ import { computeEnergy, spendEnergy } from '@/lib/pvp/energy'
 
 const schema = z.object({
   attackerTeamIds: z.array(z.string()).length(3),
+  mode: z.enum(['auto', 'manual']).optional(),
 })
 
 export async function POST(req: NextRequest) {
@@ -125,6 +126,7 @@ export async function POST(req: NextRequest) {
       charisma:          stats.charisma,
       auraId:            (t as any).auraId ?? null,
       equippedAbilities: JSON.parse(t.equippedAbilities || '[]') as string[],
+      equippedPassives:  JSON.parse((t as any).equippedPassives || '[]') as string[],
       avatarSnapshot: {
         appearance: {
           palette:      appearance.palette,
@@ -147,6 +149,8 @@ export async function POST(req: NextRequest) {
   let state
   try {
     state = initBattleState(attackerMembers, defenderMembers)
+    // Set battle mode (auto is default, already set in engine)
+    if (body.mode) state.mode = body.mode
   } catch (err) {
     console.error('[pvp/start] Engine error:', err)
     return NextResponse.json({ error: 'ENGINE_ERROR', detail: String(err) }, { status: 500 })

--- a/app/api/pvp/start/route.ts
+++ b/app/api/pvp/start/route.ts
@@ -5,6 +5,7 @@ import { db } from '@/lib/db'
 import { initBattleState } from '@/lib/pvp/engine'
 import type { InitTeamMember } from '@/lib/pvp/engine'
 import { getPaletteById } from '@/lib/catalogs/appearance'
+import { computeEnergy, spendEnergy } from '@/lib/pvp/energy'
 
 const schema = z.object({
   attackerTeamIds: z.array(z.string()).length(3),
@@ -36,6 +37,27 @@ export async function POST(req: NextRequest) {
   if (existing) {
     return NextResponse.json({ error: 'BATTLE_IN_PROGRESS', battleId: existing.id }, { status: 409 })
   }
+
+  // Verificar y deducir energía
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dba = db as any
+  const userEnergy = await dba.user.findUnique({
+    where: { id: userId },
+    select: { pvpEnergy: true, pvpEnergyRegenAt: true },
+  }) as { pvpEnergy: number | null; pvpEnergyRegenAt: Date | null } | null
+
+  const { energy: currentEnergy, regenAt: currentRegenAt } = computeEnergy(
+    userEnergy?.pvpEnergy ?? 10,
+    userEnergy?.pvpEnergyRegenAt ?? null,
+  )
+  if (currentEnergy <= 0) {
+    return NextResponse.json({ error: 'NO_ENERGY', energyRegenAt: currentRegenAt?.toISOString() ?? null }, { status: 429 })
+  }
+  const { energy: newEnergy, regenAt: newRegenAt } = spendEnergy(currentEnergy, currentRegenAt)
+  await dba.user.update({
+    where: { id: userId },
+    data: { pvpEnergy: newEnergy, pvpEnergyRegenAt: newRegenAt },
+  })
 
   // Buscar oponente aleatorio (otro usuario con 3 Therians activos y con nombre)
   const opponents = await db.therian.findMany({

--- a/app/api/pvp/status/route.ts
+++ b/app/api/pvp/status/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import { db } from '@/lib/db'
+import {
+  getRankFromMmr,
+  needsWeeklyReset,
+  currentMonthKey,
+  WEEKLY_WINS_REQUIRED,
+  MONTHLY_REWARDS,
+} from '@/lib/pvp/mmr'
+import { computeEnergy } from '@/lib/pvp/energy'
+
+export async function GET() {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dba = db as any
+  const user = await dba.user.findUnique({
+    where: { id: session.user.id },
+    select: {
+      mmr: true,
+      peakMmr: true,
+      weeklyPvpWins: true,
+      weeklyPvpResetAt: true,
+      lastWeeklyChestAt: true,
+      lastMonthlyRewardMonth: true,
+      pvpEnergy: true,
+      pvpEnergyRegenAt: true,
+    },
+  }) as {
+    mmr: number
+    peakMmr: number
+    weeklyPvpWins: number
+    weeklyPvpResetAt: Date | null
+    lastWeeklyChestAt: Date | null
+    lastMonthlyRewardMonth: string | null
+    pvpEnergy: number | null
+    pvpEnergyRegenAt: Date | null
+  } | null
+
+  if (!user) return NextResponse.json({ error: 'NOT_FOUND' }, { status: 404 })
+
+  // Compute regenerated energy and persist if changed
+  const { energy, regenAt: energyRegenAt, dirty } = computeEnergy(
+    user.pvpEnergy ?? 10,
+    user.pvpEnergyRegenAt ?? null,
+  )
+  if (dirty) {
+    await dba.user.update({
+      where: { id: session.user.id },
+      data: { pvpEnergy: energy, pvpEnergyRegenAt: energyRegenAt },
+    })
+  }
+
+  const resetNeeded = needsWeeklyReset(user.weeklyPvpResetAt)
+  const effectiveWins = resetNeeded ? 0 : user.weeklyPvpWins
+
+  const chestEligible = effectiveWins >= WEEKLY_WINS_REQUIRED
+  const alreadyClaimedChest =
+    !resetNeeded &&
+    user.lastWeeklyChestAt !== null &&
+    user.weeklyPvpResetAt !== null &&
+    user.lastWeeklyChestAt >= user.weeklyPvpResetAt
+  const chestAvailable = chestEligible && !alreadyClaimedChest
+
+  const rank = getRankFromMmr(user.mmr)
+  const peakRank = getRankFromMmr(user.peakMmr)
+  const month = currentMonthKey()
+  const alreadyClaimedMonthly = user.lastMonthlyRewardMonth === month
+  const monthlyReward = MONTHLY_REWARDS[peakRank]
+
+  return NextResponse.json({
+    mmr: user.mmr,
+    rank,
+    peakMmr: user.peakMmr,
+    peakRank,
+    weeklyPvpWins: effectiveWins,
+    weeklyRequired: WEEKLY_WINS_REQUIRED,
+    chestAvailable,
+    alreadyClaimedChest,
+    currentMonth: month,
+    monthlyReward,
+    alreadyClaimedMonthly,
+    energy,
+    energyMax: 10,
+    energyRegenAt: energyRegenAt ? energyRegenAt.toISOString() : null,
+  })
+}

--- a/app/api/pvp/team/route.ts
+++ b/app/api/pvp/team/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getSession } from '@/lib/session'
+import { db } from '@/lib/db'
+import { toTherianDTO } from '@/lib/therian-dto'
+
+const saveSchema = z.object({
+  teamIds: z.array(z.string()).length(3),
+})
+
+export async function GET() {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dba = db as any
+  const user = await dba.user.findUnique({
+    where: { id: session.user.id },
+    select: { savedPvpTeam: true },
+  }) as { savedPvpTeam: string | null } | null
+
+  if (!user?.savedPvpTeam) {
+    return NextResponse.json({ teamIds: [], therians: [] })
+  }
+
+  const teamIds: string[] = JSON.parse(user.savedPvpTeam)
+  const therians = await db.therian.findMany({
+    where: { id: { in: teamIds }, userId: session.user.id, status: 'active' },
+  })
+
+  // Return in the same order as teamIds, filter out missing ones
+  const therianMap = new Map(therians.map(t => [t.id, t]))
+  const orderedTherians = teamIds
+    .map(id => therianMap.get(id))
+    .filter((t): t is typeof therians[0] => !!t)
+
+  return NextResponse.json({
+    teamIds: orderedTherians.map(t => t.id),
+    therians: orderedTherians.map(t => toTherianDTO(t)),
+  })
+}
+
+export async function POST(req: NextRequest) {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  let body
+  try { body = saveSchema.parse(await req.json()) }
+  catch { return NextResponse.json({ error: 'INVALID_INPUT' }, { status: 400 }) }
+
+  // Validate that all 3 therians belong to the user and are active
+  const therians = await db.therian.findMany({
+    where: { id: { in: body.teamIds }, userId: session.user.id, status: 'active' },
+    select: { id: true },
+  })
+  if (therians.length !== 3) {
+    return NextResponse.json({ error: 'INVALID_TEAM' }, { status: 400 })
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dba = db as any
+  await dba.user.update({
+    where: { id: session.user.id },
+    data: { savedPvpTeam: JSON.stringify(body.teamIds) },
+  })
+
+  return NextResponse.json({ ok: true, teamIds: body.teamIds })
+}

--- a/app/api/therian/equip-abilities/route.ts
+++ b/app/api/therian/equip-abilities/route.ts
@@ -5,11 +5,13 @@ import { db } from '@/lib/db'
 import { toTherianDTO } from '@/lib/therian-dto'
 import { ABILITY_BY_ID } from '@/lib/pvp/abilities'
 
-const MAX_ABILITIES = 3
+const MAX_ACTIVE   = 3
+const MAX_PASSIVES = 2
 
 const schema = z.object({
   therianId:  z.string(),
-  abilityIds: z.array(z.string()).max(MAX_ABILITIES),
+  abilityIds: z.array(z.string()).max(MAX_ACTIVE),   // habilidades activas
+  passiveIds: z.array(z.string()).max(MAX_PASSIVES).optional(), // habilidades pasivas
 })
 
 export async function POST(req: NextRequest) {
@@ -17,21 +19,25 @@ export async function POST(req: NextRequest) {
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
   }
+  const userId = session.user.id
 
   let body
   try { body = schema.parse(await req.json()) }
   catch { return NextResponse.json({ error: 'INVALID_INPUT' }, { status: 400 }) }
 
+  const allIds     = [...body.abilityIds, ...(body.passiveIds ?? [])]
+  const passiveIds = body.passiveIds ?? []
+
   // Validar que el Therian pertenece al usuario y está activo
   const therian = await db.therian.findFirst({
-    where: { id: body.therianId, userId: session.user.id, status: 'active' },
+    where: { id: body.therianId, userId, status: 'active' },
   })
   if (!therian) {
     return NextResponse.json({ error: 'NO_THERIAN' }, { status: 404 })
   }
 
-  // Validar que todas las habilidades existen y no son innatas ni pasivas (pasivas sí se permiten)
-  for (const id of body.abilityIds) {
+  // Validar cada habilidad
+  for (const id of allIds) {
     const ability = ABILITY_BY_ID[id]
     if (!ability) {
       return NextResponse.json({ error: 'INVALID_ABILITY', abilityId: id }, { status: 400 })
@@ -39,11 +45,54 @@ export async function POST(req: NextRequest) {
     if (ability.isInnate) {
       return NextResponse.json({ error: 'CANNOT_EQUIP_INNATE', abilityId: id }, { status: 400 })
     }
+    // Activas solo en abilityIds, pasivas solo en passiveIds
+    if (ability.type === 'passive' && body.abilityIds.includes(id)) {
+      return NextResponse.json({ error: 'PASSIVE_IN_ACTIVE_SLOT', abilityId: id }, { status: 400 })
+    }
+    if (ability.type === 'active' && passiveIds.includes(id)) {
+      return NextResponse.json({ error: 'ACTIVE_IN_PASSIVE_SLOT', abilityId: id }, { status: 400 })
+    }
   }
 
-  const updated = await db.therian.update({
+  // Validar ownership — cada habilidad debe estar en el inventario del usuario
+  // con cantidad suficiente (cantidad total - ya equipadas en otros Therians)
+  const dba = db as any
+  for (const id of allIds) {
+    // Buscar cuántas copias tiene el usuario
+    const inv = await dba.userAbilityInventory.findUnique({
+      where: { userId_abilityId: { userId, abilityId: id } },
+    }) as { quantity: number } | null
+
+    const owned = inv?.quantity ?? 0
+
+    // Contar cuántos otros Therians del usuario ya tienen esta habilidad equipada
+    const ability = ABILITY_BY_ID[id]!
+    const field = ability.type === 'passive' ? 'equippedPassives' : 'equippedAbilities'
+    const otherTherians = await db.therian.findMany({
+      where: { userId, id: { not: body.therianId }, status: 'active' },
+      select: { [field]: true },
+    })
+    const equippedElsewhere = otherTherians.filter(t =>
+      (JSON.parse((t as any)[field] || '[]') as string[]).includes(id)
+    ).length
+
+    if (owned - equippedElsewhere < 1) {
+      return NextResponse.json({
+        error: 'NOT_ENOUGH_COPIES',
+        abilityId: id,
+        owned,
+        equippedElsewhere,
+      }, { status: 409 })
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updated = await (db as any).therian.update({
     where: { id: therian.id },
-    data: { equippedAbilities: JSON.stringify(body.abilityIds) },
+    data: {
+      equippedAbilities: JSON.stringify(body.abilityIds),
+      equippedPassives:  JSON.stringify(passiveIds),
+    },
   })
 
   return NextResponse.json({ therian: toTherianDTO(updated) })

--- a/app/api/user/abilities/route.ts
+++ b/app/api/user/abilities/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server'
+import { getSession } from '@/lib/session'
+import { db } from '@/lib/db'
+
+export async function GET() {
+  const session = await getSession()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'UNAUTHORIZED' }, { status: 401 })
+  }
+
+  const userId = session.user.id
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dba = db as any
+
+  const inventory = await dba.userAbilityInventory.findMany({
+    where: { userId },
+    orderBy: { obtainedAt: 'asc' },
+  }) as { abilityId: string; quantity: number }[]
+
+  const therians = await db.therian.findMany({
+    where: { userId, status: 'active' },
+    select: { id: true, name: true, equippedAbilities: true, equippedPassives: true },
+  })
+
+  const result = inventory.map(inv => {
+    const equippedIn: string[] = []
+    for (const t of therians) {
+      const actives  = JSON.parse(t.equippedAbilities || '[]') as string[]
+      const passives = JSON.parse(t.equippedPassives || '[]') as string[]
+      if (actives.includes(inv.abilityId) || passives.includes(inv.abilityId)) {
+        equippedIn.push(t.id)
+      }
+    }
+    return { abilityId: inv.abilityId, quantity: inv.quantity, equippedIn }
+  })
+
+  return NextResponse.json({ inventory: result })
+}

--- a/app/pvp/page.tsx
+++ b/app/pvp/page.tsx
@@ -5,7 +5,7 @@ import { db } from '@/lib/db'
 import { toTherianDTO } from '@/lib/therian-dto'
 import SignOutButton from '@/components/SignOutButton'
 import CurrencyDisplay from '@/components/CurrencyDisplay'
-import PvpRoom from '@/components/pvp/PvpRoom'
+import PvpPageClient from '@/components/pvp/PvpPageClient'
 
 export const dynamic = 'force-dynamic'
 
@@ -39,7 +39,8 @@ export default async function PvpPage() {
     <div className="min-h-screen bg-[#08080F] relative">
       {/* Fondo */}
       <div className="fixed inset-0 pointer-events-none">
-        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[600px] h-[300px] rounded-full blur-[150px] opacity-8"
+        <div
+          className="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[400px] rounded-full blur-[150px] opacity-10"
           style={{ background: 'radial-gradient(ellipse, #C0392B, transparent)' }}
         />
       </div>
@@ -57,8 +58,8 @@ export default async function PvpPage() {
       </nav>
 
       {/* Content */}
-      <main className="relative z-10 max-w-lg mx-auto px-4 py-8">
-        <PvpRoom therians={dtos} activeBattleId={activeBattle?.id ?? null} />
+      <main className="relative z-10 max-w-5xl mx-auto px-4 py-8">
+        <PvpPageClient therians={dtos} activeBattleId={activeBattle?.id ?? null} />
       </main>
     </div>
   )

--- a/app/therian/page.tsx
+++ b/app/therian/page.tsx
@@ -12,6 +12,7 @@ import CurrencyDisplay from '@/components/CurrencyDisplay'
 import NavShopButton from '@/components/NavShopButton'
 import NavFusionButton from '@/components/NavFusionButton'
 import NavInventoryButton from '@/components/NavInventoryButton'
+import NavPvpButton from '@/components/NavPvpButton'
 import PassiveIncomeCard from '@/components/PassiveIncomeCard'
 import TutorialCard from '@/components/TutorialCard'
 import { ACHIEVEMENTS } from '@/lib/catalogs/achievements'
@@ -95,7 +96,7 @@ export default async function TherianPage() {
           <NavInventoryButton />
           <CurrencyDisplay />
           <NavShopButton therian={primaryTherian} />
-          <Link href="/pvp" className="text-[#8B84B0] hover:text-white text-sm transition-colors">⚔️ PvP</Link>
+          <NavPvpButton />
           <Link href="/leaderboard" className="text-[#8B84B0] hover:text-white text-sm transition-colors">🏆 Top</Link>
           <SignOutButton/>
         </div>

--- a/app/therian/page.tsx
+++ b/app/therian/page.tsx
@@ -89,7 +89,7 @@ export default async function TherianPage() {
       </div>
 
       {/* Navbar */}
-      <nav className="relative z-10 border-b border-white/5 bg-[#08080F]/80 backdrop-blur-sm px-6 py-4 flex items-center justify-between">
+      <nav className="relative z-40 border-b border-white/5 bg-[#08080F]/80 backdrop-blur-sm px-6 py-4 flex items-center justify-between">
         <span className="text-xl font-bold gradient-text">therian.biz</span>
         <div className="flex items-center gap-4">
           <NavFusionButton />
@@ -97,6 +97,7 @@ export default async function TherianPage() {
           <CurrencyDisplay />
           <NavShopButton therian={primaryTherian} />
           <NavPvpButton />
+          <Link href="/spellbook" className="text-[#8B84B0] hover:text-white text-sm transition-colors">📖 Hechizos</Link>
           <Link href="/leaderboard" className="text-[#8B84B0] hover:text-white text-sm transition-colors">🏆 Top</Link>
           <SignOutButton/>
         </div>

--- a/components/BattleArena.tsx
+++ b/components/BattleArena.tsx
@@ -295,10 +295,12 @@ export default function BattleArena({ challenger, target, result, onComplete }: 
           {/* Challenger side */}
           <div className="flex flex-col items-center gap-2">
             <div className="relative">
-              <div className={`transition-transform duration-200 ${
-                lungeLeft ? 'translate-x-6' : ''
-              } ${shakeLeft ? 'animate-[shake_0.3s_ease]' : ''}`}>
-                <TherianAvatar therian={challenger} size={100} animated={phase === 'intro'} />
+              {/* Lunge (outer) and shake (inner) on separate layers to avoid transform conflicts */}
+              <div className={`transition-transform duration-[180ms] ease-out ${lungeLeft ? 'translate-x-6' : ''}`}
+                style={{ willChange: 'transform' }}>
+                <div className={shakeLeft ? 'animate-[shake_0.28s_ease]' : ''}>
+                  <TherianAvatar therian={challenger} size={100} animated={phase === 'intro'} />
+                </div>
               </div>
               {/* Floating texts on challenger */}
               {floatingTexts.filter(f => f.side === 'left').map(f => (
@@ -323,10 +325,11 @@ export default function BattleArena({ challenger, target, result, onComplete }: 
           {/* Target side */}
           <div className="flex flex-col items-center gap-2">
             <div className="relative">
-              <div className={`transition-transform duration-200 ${
-                lungeRight ? '-translate-x-6' : ''
-              } ${shakeRight ? 'animate-[shake_0.3s_ease]' : ''}`}>
-                <TherianAvatar therian={target} size={100} animated={phase === 'intro'} />
+              <div className={`transition-transform duration-[180ms] ease-out ${lungeRight ? '-translate-x-6' : ''}`}
+                style={{ willChange: 'transform' }}>
+                <div className={shakeRight ? 'animate-[shake_0.28s_ease]' : ''}>
+                  <TherianAvatar therian={target} size={100} animated={phase === 'intro'} />
+                </div>
               </div>
               {floatingTexts.filter(f => f.side === 'right').map(f => (
                 <div key={f.id} className="absolute -top-6 left-1/2 -translate-x-1/2 text-sm font-bold animate-[floatUp_1s_ease_forwards] whitespace-nowrap pointer-events-none"
@@ -409,8 +412,9 @@ export default function BattleArena({ challenger, target, result, onComplete }: 
         }
         @keyframes shake {
           0%,100% { transform: translateX(0); }
-          25%      { transform: translateX(-5px); }
-          75%      { transform: translateX(5px); }
+          20%      { transform: translateX(-6px); }
+          50%      { transform: translateX(6px); }
+          80%      { transform: translateX(-3px); }
         }
         @keyframes resultAppear {
           0%   { opacity: 0; transform: scale(0.88) translateY(10px); }

--- a/components/DailyActionButtons.tsx
+++ b/components/DailyActionButtons.tsx
@@ -170,7 +170,8 @@ export default function DailyActionButtons({ therian, onSpinStart, onAction, onE
             const bgClass     = isHighlighted ? slot.bg     : spinning ? slot.bgSpin     : slot.bgIdle
             const textClass   = isHighlighted ? slot.text   : spinning ? slot.textSpin   : slot.textIdle
             const barClass    = isHighlighted ? slot.bar    : spinning ? slot.barSpin    : slot.barIdle
-            const dur = isHighlighted ? '60ms' : '150ms'
+            // During fast spin keep non-highlighted slots snappy so transitions complete within each frame
+            const dur = isHighlighted ? '55ms' : spinning ? '45ms' : '150ms'
             const gained = therian.actionGains[slot.type] ?? 0
             const barPct = Math.round((gained / maxGain) * 100)
 
@@ -178,12 +179,13 @@ export default function DailyActionButtons({ therian, onSpinStart, onAction, onE
               <div
                 key={slot.type}
                 className={[
-                  'relative flex flex-col items-center gap-1 p-3 rounded-xl border transition-all',
+                  'relative flex flex-col items-center gap-1 p-3 rounded-xl border',
+                  'transition-[border-color,background-color,opacity,transform,box-shadow]',
                   borderClass, bgClass,
                   isHighlighted ? `scale-105 ${slot.shadow}` : '',
                   hasWinner && !isWinner ? 'opacity-25' : '',
                 ].join(' ')}
-                style={{ transitionDuration: dur }}
+                style={{ transitionDuration: dur, willChange: spinning ? 'transform, opacity' : 'auto' }}
               >
                 <span className={`text-xl transition-transform ${isHighlighted ? 'scale-110' : ''}`}
                   style={{ transitionDuration: dur }}>

--- a/components/FusionModal.tsx
+++ b/components/FusionModal.tsx
@@ -68,7 +68,7 @@ export default function FusionModal({ therians, inventory, onClose, onSuccess }:
   const [localInventory, setLocalInventory] = useState<InventoryItemDTO[]>(inventory)
   const [slots, setSlots] = useState<FusionSlot[]>([null, null, null])
   const [phase, setPhase] = useState<Phase>('select')
-  const [result, setResult] = useState<{ success: boolean; therian: TherianDTO; successRate: number } | null>(null)
+  const [result, setResult] = useState<{ success: boolean; therian: TherianDTO; successRate: number; encapsulated: boolean } | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [showProbs, setShowProbs] = useState(false)
   const [hasFused, setHasFused] = useState(false)
@@ -209,7 +209,7 @@ export default function FusionModal({ therians, inventory, onClose, onSuccess }:
         setPhase('select')
         return
       }
-      setResult({ success: data.success, therian: data.therian, successRate: data.successRate * 100 })
+      setResult({ success: data.success, therian: data.therian, successRate: data.successRate * 100, encapsulated: !!data.encapsulated })
       setHasFused(true)
       setPhase('result')
       // Refresh both therians and inventory
@@ -486,6 +486,15 @@ export default function FusionModal({ therians, inventory, onClose, onSuccess }:
                 <p className="text-red-400 font-bold text-base tracking-widest uppercase">✗ Fusión fallida</p>
                 <p className="text-red-300/60 text-xs mt-0.5">
                   Probabilidad era {result.successRate}% — Therian de la misma rareza obtenido
+                </p>
+              </div>
+            )}
+
+            {result.encapsulated && (
+              <div className="flex items-start gap-2 rounded-xl border border-amber-500/30 bg-amber-500/8 px-3 py-2.5 text-xs">
+                <span className="text-amber-400 flex-shrink-0">💊</span>
+                <p className="text-amber-300/80 leading-relaxed">
+                  Sin slots activos disponibles — el Therian fue enviado a la <span className="font-semibold text-amber-300">cápsula</span>. Libera un slot o compra uno nuevo para activarlo.
                 </p>
               </div>
             )}

--- a/components/MissionsPanel.tsx
+++ b/components/MissionsPanel.tsx
@@ -57,6 +57,7 @@ export default function MissionsPanel() {
       })
       if (res.ok) {
         setCongrats({ title: m.title, rewardLabel: m.rewardLabel })
+        window.dispatchEvent(new Event('wallet-update'))
         await fetchMissions()
         router.refresh()
       }

--- a/components/NavPvpButton.tsx
+++ b/components/NavPvpButton.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function NavPvpButton() {
+  return (
+    <Link
+      href="/pvp"
+      className="flex items-center gap-1.5 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-1.5 text-xs font-semibold text-red-300 hover:bg-red-500/10 hover:border-red-500/40 transition-all"
+    >
+      ⚔️ PvP
+    </Link>
+  )
+}

--- a/components/pvp/BattleField.tsx
+++ b/components/pvp/BattleField.tsx
@@ -2,13 +2,23 @@
 
 import { useState, useEffect, useRef } from 'react'
 import type { BattleState, TurnSlot, TurnSnapshot, ActionLogEntry, AvatarSnapshot } from '@/lib/pvp/types'
+import type { Ability } from '@/lib/pvp/types'
+import { ABILITY_BY_ID } from '@/lib/pvp/abilities'
 import TherianAvatar from '@/components/TherianAvatar'
 import type { TherianDTO } from '@/lib/therian-dto'
+
+export interface BattleRewards {
+  mmrDelta: number
+  newMmr: number
+  rank: string
+  goldEarned: number
+  weeklyPvpWins: number
+}
 
 interface Props {
   battleId: string
   initialState: BattleState
-  onComplete: (won: boolean) => void
+  onComplete: (won: boolean, rewards?: BattleRewards) => void
 }
 
 interface AnimInfo {
@@ -19,13 +29,83 @@ interface AnimInfo {
   frame:     number
 }
 
-// ─── Archetype helpers ──────────────────────────────────────────────────────
+interface FloatNum {
+  id:        number
+  therianId: string
+  label:     string
+  color:     string
+}
+
+interface ActiveAbilityInfo {
+  abilityId:   string
+  abilityName: string
+  archetype:   string
+  actorName:   string | null
+  resultLines: string[]
+}
+
+// ─── Pure helpers (exported for tests) ────────────────────────────────────────
+
+export function describeAbility(ab: Ability): string {
+  const e = ab.effect
+  const parts: string[] = []
+  if (e.damage  !== undefined) parts.push(`Daño base ×${e.damage}`)
+  if (e.heal    !== undefined) parts.push(`Curación base ×${e.heal}`)
+  if (e.stun    !== undefined) parts.push(`Aturde ${e.stun} turno${e.stun !== 1 ? 's' : ''}`)
+  if (e.buff)    parts.push(`+${Math.round(e.buff.pct * 100)}% ${e.buff.stat} por ${e.buff.turns} turnos`)
+  if (e.debuff)  parts.push(`${Math.round(e.debuff.pct * 100)}% ${e.debuff.stat} por ${e.debuff.turns} turnos`)
+  if (e.reflect) parts.push(`Refleja ${Math.round(e.reflect * 100)}% del daño recibido`)
+  if (e.damageReduction) parts.push(`Reduce ${Math.round(e.damageReduction * 100)}% el daño recibido`)
+  if (e.tiebreaker) parts.push('Actúa primero en empates de velocidad')
+  return parts.join('. ')
+}
+
+export function hpBarColor(current: number, max: number): 'bg-emerald-500' | 'bg-amber-500' | 'bg-red-500' {
+  const pct = max > 0 ? current / max : 0
+  if (pct > 0.6) return 'bg-emerald-500'
+  if (pct > 0.3) return 'bg-amber-500'
+  return 'bg-red-500'
+}
+
+export function resultLines(entry: ActionLogEntry): string[] {
+  if (entry.abilityId === 'stun') return ['Aturdido: saltea turno']
+  const lines = entry.results.map(r => {
+    if (r.damage !== undefined) return r.blocked ? `Bloqueado (${r.damage} dmg)` : `${r.damage} daño${r.died ? ' 💀' : ''}`
+    if (r.heal   !== undefined) return `+${r.heal} HP`
+    if (r.stun   !== undefined) return `Aturde ${r.stun}t`
+    if (r.effect !== undefined) return r.effect
+    return ''
+  }).filter(Boolean)
+  // If multi-target, add total damage summary
+  if (entry.results.length > 1) {
+    const total = entry.results.reduce((s, r) => s + (r.damage ?? 0), 0)
+    if (total > 0) lines.push(`Total: ${total} daño`)
+  }
+  return lines
+}
+
+export function applySnapshot(base: BattleState, snap: TurnSnapshot): BattleState {
+  return {
+    ...base,
+    turnIndex: snap.turnIndex,
+    round:     snap.round,
+    status:    snap.status,
+    winnerId:  snap.winnerId,
+    slots: base.slots.map(slot => {
+      const s = snap.slots.find(ss => ss.therianId === slot.therianId)
+      if (!s) return slot
+      return { ...slot, currentHp: s.currentHp, isDead: s.isDead, effects: s.effects, cooldowns: s.cooldowns, effectiveAgility: s.effectiveAgility }
+    }),
+  }
+}
+
+// ─── Archetype helpers ────────────────────────────────────────────────────────
 
 const ARCH_META = {
   forestal:  { emoji: '🌿', border: 'border-emerald-500/50', text: 'text-emerald-400', bg: 'bg-emerald-500/15' },
-  electrico: { emoji: '⚡', border: 'border-yellow-500/50',  text: 'text-yellow-400',  bg: 'bg-yellow-500/15' },
-  acuatico:  { emoji: '💧', border: 'border-blue-500/50',    text: 'text-blue-400',    bg: 'bg-blue-500/15'  },
-  volcanico: { emoji: '🔥', border: 'border-orange-500/50',  text: 'text-orange-400',  bg: 'bg-orange-500/15'},
+  electrico: { emoji: '⚡', border: 'border-yellow-500/50',  text: 'text-yellow-400',  bg: 'bg-yellow-500/15'  },
+  acuatico:  { emoji: '💧', border: 'border-blue-500/50',    text: 'text-blue-400',    bg: 'bg-blue-500/15'    },
+  volcanico: { emoji: '🔥', border: 'border-orange-500/50',  text: 'text-orange-400',  bg: 'bg-orange-500/15'  },
 } as const
 
 function archMeta(archetype: string) {
@@ -33,10 +113,7 @@ function archMeta(archetype: string) {
 }
 
 const AURA_LABEL_FALLBACK: Record<string, string> = {
-  hp:      '🌿 Vitalidad',
-  damage:  '🔥 Combate',
-  defense: '💧 Escudo',
-  agility: '⚡ Celeridad',
+  hp: '🌿 Vitalidad', damage: '🔥 Combate', defense: '💧 Escudo', agility: '⚡ Celeridad',
 }
 
 function getAuraLabel(aura: { name?: string; type?: string }): string {
@@ -50,18 +127,17 @@ const SPEED_OPTIONS = [
   { label: '4×', ms: 350  },
 ]
 
-// ─── Avatar ──────────────────────────────────────────────────────────────────
+// Module-level counter for unique float number IDs
+let floatCounter = 0
+
+// ─── SlotAvatar ───────────────────────────────────────────────────────────────
 
 function SlotAvatar({ slot }: { slot: TurnSlot }) {
   const snap: AvatarSnapshot | undefined = slot.avatarSnapshot
   const meta = archMeta(slot.archetype)
 
   if (!snap) {
-    return (
-      <div className="w-16 h-16 flex items-center justify-center text-4xl">
-        {meta.emoji}
-      </div>
-    )
+    return <div className="w-16 h-16 flex items-center justify-center text-4xl">{meta.emoji}</div>
   }
 
   const fakeDto = {
@@ -82,11 +158,11 @@ function SlotAvatar({ slot }: { slot: TurnSlot }) {
   return <TherianAvatar therian={fakeDto} size={64} />
 }
 
-// ─── HP Bar ──────────────────────────────────────────────────────────────────
+// ─── HpBar ────────────────────────────────────────────────────────────────────
 
 function HpBar({ current, max }: { current: number; max: number }) {
-  const pct = Math.max(0, (current / max) * 100)
-  const color = pct > 60 ? 'bg-emerald-500' : pct > 30 ? 'bg-amber-500' : 'bg-red-500'
+  const pct   = Math.max(0, (current / max) * 100)
+  const color = hpBarColor(current, max)
   return (
     <div className="h-1.5 bg-white/10 rounded-full overflow-hidden">
       <div className={`h-full ${color} transition-all duration-700`} style={{ width: `${pct}%` }} />
@@ -94,11 +170,11 @@ function HpBar({ current, max }: { current: number; max: number }) {
   )
 }
 
-// ─── Turn Queue Bar ──────────────────────────────────────────────────────────
+// ─── TurnQueueBar ─────────────────────────────────────────────────────────────
 
-function TurnQueueBar({
-  slots, turnIndex, actorIndex,
-}: { slots: TurnSlot[]; turnIndex: number; actorIndex: number }) {
+function TurnQueueBar({ slots, turnIndex, actorIndex }: {
+  slots: TurnSlot[]; turnIndex: number; actorIndex: number
+}) {
   const attackers = slots.filter(s => s.side === 'attacker')
   const defenders = slots.filter(s => s.side === 'defender')
 
@@ -126,98 +202,182 @@ function TurnQueueBar({
   }
 
   return (
-    <div className="flex items-center justify-center gap-1">
+    <div className="flex items-center justify-center gap-1.5">
       {attackers.map(s => <Chip key={s.therianId} slot={s} />)}
-      <span className="text-white/20 text-xs mx-1.5">|</span>
+      <span className="text-white/20 text-[10px] font-bold mx-1">vs</span>
       {defenders.map(s => <Chip key={s.therianId} slot={s} />)}
     </div>
   )
 }
 
-// ─── Slot Card ───────────────────────────────────────────────────────────────
+// ─── ArenaSlot ────────────────────────────────────────────────────────────────
 
-function SlotCard({
-  slot, isActor, isNext, onCardRef, onAvatarRef,
-}: {
+function ArenaSlot({ slot, isActor, isNext, onCardRef, onAvatarRef, mirrored, floats }: {
   slot:        TurnSlot
   isActor:     boolean
   isNext:      boolean
   onCardRef:   (el: HTMLDivElement | null) => void
   onAvatarRef: (el: HTMLDivElement | null) => void
+  mirrored:    boolean
+  floats:      FloatNum[]
 }) {
   const meta = archMeta(slot.archetype)
+
+  const borderClass = slot.isDead
+    ? 'border-white/5 bg-white/2'
+    : isActor
+      ? `${meta.border} ${meta.bg} ring-2 ring-white/50 shadow-[0_0_14px_rgba(255,255,255,0.08)]`
+      : isNext
+        ? `${meta.border} bg-white/5 ring-1 ring-white/15`
+        : 'border-white/10 bg-white/3'
 
   return (
     <div
       ref={onCardRef}
-      className={`relative rounded-xl border p-2 transition-colors transition-opacity duration-500 ${
-        slot.isDead
-          ? 'opacity-20 grayscale border-white/5 bg-white/3'
-          : isActor
-            ? `${meta.border} ${meta.bg} ring-2 ring-white/60 shadow-[0_0_18px_rgba(255,255,255,0.1)]`
-            : isNext
-              ? `${meta.border} bg-white/5 ring-1 ring-white/15`
-              : 'border-white/10 bg-white/3'
-      }`}
+      className={`relative rounded-xl border p-2 transition-all duration-500 ${borderClass} ${slot.isDead ? 'opacity-30 grayscale' : ''}`}
     >
-      {/* Nombre + indicador de turno */}
-      <div className="flex items-center gap-1.5 mb-1.5">
-        <span className="text-sm leading-none">{meta.emoji}</span>
-        <span className="text-xs font-medium text-white/80 truncate flex-1">
-          {slot.name ?? slot.archetype}
-        </span>
-        {isActor && !slot.isDead && (
-          <span className="text-[11px] font-bold text-white/80 animate-pulse">⚔</span>
-        )}
-      </div>
-
-      {/* HP */}
+      {/* HP bar + text */}
       <HpBar current={slot.currentHp} max={slot.maxHp} />
-      <div className="flex justify-between mt-1 mb-2">
-        <span className="text-[10px] text-white/30">{slot.currentHp}/{slot.maxHp}</span>
+      <div className="flex justify-between items-center mt-0.5 mb-1.5">
+        <span className="text-[9px] text-white/30">{slot.currentHp}/{slot.maxHp}</span>
         {slot.effects.length > 0 && (
-          <span className="text-[10px] text-amber-400/60">
+          <span className="text-[10px]">
             {slot.effects.map(e => e.type === 'stun' ? '😵' : e.type === 'buff' ? '↑' : '↓').join('')}
           </span>
         )}
       </div>
 
-      {/* Avatar — ref para movimiento de ataque */}
-      <div
-        ref={onAvatarRef}
-        className={`flex justify-center ${slot.isDead ? 'opacity-30' : ''}`}
-        style={{ willChange: 'transform' }}
-      >
-        <SlotAvatar slot={slot} />
+      {/* Avatar with float numbers — outer div for float anchor */}
+      <div className="relative flex justify-center">
+        {/* Float numbers — absolute above avatar, not mirrored */}
+        {floats.length > 0 && (
+          <div
+            className="absolute inset-x-0 flex flex-col items-center pointer-events-none"
+            style={{ bottom: '100%', zIndex: 20 }}
+          >
+            {floats.map(f => (
+              <span
+                key={f.id}
+                className={`text-sm font-extrabold leading-none select-none ${f.color}`}
+                style={{ animation: 'floatUp 1.2s ease-out forwards' }}
+              >
+                {f.label}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* WAAPI wrapper — translated by animation, does NOT have mirror so dx/dy are correct */}
+        <div ref={onAvatarRef} style={{ willChange: 'transform' }}>
+          {/* Mirror applied only to the visual content */}
+          <div style={{ transform: mirrored ? 'scaleX(-1)' : 'none' }}
+               className={slot.isDead ? 'opacity-30' : ''}>
+            <SlotAvatar slot={slot} />
+          </div>
+        </div>
+      </div>
+
+      {/* Name */}
+      <p className="text-[10px] text-center text-white/60 mt-1.5 truncate font-medium">
+        {slot.name ?? slot.archetype}
+      </p>
+
+      {/* Equipped ability dots (Phase 4: hover to inspect) */}
+      {slot.equippedAbilities.length > 0 && (
+        <div className="flex justify-center gap-1 mt-1.5">
+          {slot.equippedAbilities.slice(0, 4).map(id => {
+            const ab = ABILITY_BY_ID[id]
+            if (!ab) return null
+            const abMeta = archMeta(ab.archetype)
+            return (
+              <div
+                key={id}
+                className={`w-4 h-4 rounded-full border flex items-center justify-center text-[8px] leading-none cursor-default ${abMeta.border} ${abMeta.bg} hover:scale-125 transition-transform`}
+                title={`${ab.name}: ${describeAbility(ab)}`}
+              >
+                {abMeta.emoji}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Actor turn indicator badge */}
+      {isActor && !slot.isDead && (
+        <div className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-white flex items-center justify-center shadow-lg">
+          <span className="text-[9px] font-black text-black leading-none">⚔</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── ActiveAbilityCard ────────────────────────────────────────────────────────
+
+function ActiveAbilityCard({ info }: { info: ActiveAbilityInfo | null }) {
+  if (!info) {
+    return (
+      <div className="h-16 rounded-xl border border-white/5 bg-white/2 flex items-center justify-center">
+        <p className="text-white/15 text-xs">Esperando turno...</p>
+      </div>
+    )
+  }
+
+  const meta = archMeta(info.archetype)
+  const ab   = ABILITY_BY_ID[info.abilityId]
+  const desc = ab ? describeAbility(ab) : ''
+
+  let typeLabel = ''
+  if (ab) {
+    if (ab.type === 'passive') typeLabel = 'PASIVO'
+    else if (ab.effect.heal !== undefined) typeLabel = 'CURA'
+    else if (ab.effect.damage !== undefined) typeLabel = 'ATAQUE'
+    else typeLabel = 'EFECTO'
+  }
+
+  return (
+    <div className={`rounded-xl border p-3 ${meta.border} ${meta.bg} transition-all duration-300`}>
+      <div className="flex items-start justify-between gap-2">
+        {/* Left: archetype + name + description */}
+        <div className="flex items-start gap-2 min-w-0 flex-1">
+          <span className="text-xl leading-none flex-shrink-0 mt-0.5">{meta.emoji}</span>
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <span className={`text-sm font-bold ${meta.text}`}>{info.abilityName}</span>
+              {typeLabel && (
+                <span className={`text-[9px] px-1.5 py-0.5 rounded-full border ${meta.border} ${meta.text} opacity-60`}>
+                  {typeLabel}
+                </span>
+              )}
+            </div>
+            {desc && (
+              <p className="text-[10px] text-white/35 mt-0.5 leading-snug">{desc}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Right: actor + results */}
+        <div className="text-right flex-shrink-0 min-w-[80px]">
+          <p className="text-[9px] text-white/25 mb-0.5">{info.actorName ?? '?'}</p>
+          {info.resultLines.slice(0, 2).map((line, i) => (
+            <p key={i} className="text-xs font-semibold text-white/65 leading-snug">{line}</p>
+          ))}
+        </div>
       </div>
     </div>
   )
 }
 
-// ─── Log ─────────────────────────────────────────────────────────────────────
+// ─── LogLine ──────────────────────────────────────────────────────────────────
 
 function LogLine({ entry, isNew }: { entry: ActionLogEntry; isNew: boolean }) {
-  const first = entry.results[0]
-  let text = '', color = 'text-white/40'
-
-  if (entry.abilityId === 'stun') {
-    text = 'aturdido'; color = 'text-white/30'
-  } else if (first) {
-    if (first.damage !== undefined) {
-      text  = first.blocked ? `bloqueó (${first.damage})` : `${first.damage} dmg${first.died ? ' 💀' : ''}`
-      color = first.blocked ? 'text-amber-400/60' : 'text-red-400/70'
-    } else if (first.heal !== undefined) {
-      text = `+${first.heal} HP`; color = 'text-emerald-400/70'
-    } else if (first.stun) {
-      text = `aturde ${first.stun}t`; color = 'text-purple-400/60'
-    } else if (first.effect) {
-      text = first.effect; color = 'text-yellow-400/60'
-    }
-    if (entry.results.length > 1) {
-      const total = entry.results.reduce((s, r) => s + (r.damage ?? 0), 0)
-      if (total > 0) { text = `${total} total${entry.results.some(r => r.died) ? ' 💀' : ''}`; color = 'text-red-400/70' }
-    }
-  }
+  const lines = resultLines(entry)
+  const line  = lines[0] ?? ''
+  let color = 'text-white/40'
+  if (line.includes('HP'))       color = 'text-emerald-400/70'
+  else if (line.includes('Bloqueado')) color = 'text-amber-400/60'
+  else if (line.includes('daño'))      color = 'text-red-400/70'
+  else if (line.includes('Aturde') || line.includes('Aturdido')) color = 'text-purple-400/60'
 
   return (
     <div className={`flex items-center gap-1.5 text-xs ${isNew ? 'opacity-100' : 'opacity-45'}`}>
@@ -226,45 +386,31 @@ function LogLine({ entry, isNew }: { entry: ActionLogEntry; isNew: boolean }) {
       <span className="text-white/20">›</span>
       <span className="text-white/45 flex-shrink-0 truncate max-w-[64px]">{entry.abilityName}</span>
       <span className="text-white/20">›</span>
-      <span className={`${color} truncate flex-1`}>{text}</span>
+      <span className={`${color} truncate flex-1`}>{line}</span>
     </div>
   )
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function applySnapshot(base: BattleState, snap: TurnSnapshot): BattleState {
-  return {
-    ...base,
-    turnIndex: snap.turnIndex,
-    round:     snap.round,
-    status:    snap.status,
-    winnerId:  snap.winnerId,
-    slots: base.slots.map(slot => {
-      const s = snap.slots.find(ss => ss.therianId === slot.therianId)
-      if (!s) return slot
-      return { ...slot, currentHp: s.currentHp, isDead: s.isDead, effects: s.effects, cooldowns: s.cooldowns, effectiveAgility: s.effectiveAgility }
-    }),
-  }
-}
-
-// ─── Main Component ──────────────────────────────────────────────────────────
+// ─── Main Component ───────────────────────────────────────────────────────────
 
 export default function BattleField({ battleId, initialState, onComplete }: Props) {
-  const [displayState, setDisplayState] = useState<BattleState>(initialState)
-  const [snapshots, setSnapshots]       = useState<TurnSnapshot[]>([])
-  const [step, setStep]                 = useState(-1)
-  const [speedIdx, setSpeedIdx]         = useState(0)
-  const [fetching, setFetching]         = useState(true)
-  const [error, setError]               = useState<string | null>(null)
-  const [currentLog, setCurrentLog]     = useState<ActionLogEntry[]>([])
-  const [actorIndex, setActorIndex]     = useState(initialState.turnIndex)
-  const [animInfo, setAnimInfo]         = useState<AnimInfo | null>(null)
+  const [displayState,   setDisplayState]   = useState<BattleState>(initialState)
+  const [snapshots,      setSnapshots]      = useState<TurnSnapshot[]>([])
+  const [step,           setStep]           = useState(-1)
+  const [speedIdx,       setSpeedIdx]       = useState(0)
+  const [fetching,       setFetching]       = useState(true)
+  const [error,          setError]          = useState<string | null>(null)
+  const [currentLog,     setCurrentLog]     = useState<ActionLogEntry[]>([])
+  const [actorIndex,     setActorIndex]     = useState(initialState.turnIndex)
+  const [animInfo,       setAnimInfo]       = useState<AnimInfo | null>(null)
+  const [activeAbility,  setActiveAbility]  = useState<ActiveAbilityInfo | null>(null)
+  const [floatNums,      setFloatNums]      = useState<Map<string, FloatNum[]>>(new Map())
 
-  const finalStateRef  = useRef<BattleState>(initialState)
-  const snapshotsRef   = useRef<TurnSnapshot[]>([])
-  const completedRef   = useRef(false)
-  const baseSlotsRef   = useRef(initialState.slots)
+  const finalStateRef = useRef<BattleState>(initialState)
+  const snapshotsRef  = useRef<TurnSnapshot[]>([])
+  const completedRef  = useRef(false)
+  const baseSlotsRef  = useRef(initialState.slots)
+  const rewardsRef    = useRef<BattleRewards | undefined>(undefined)
 
   // DOM refs para WAAPI
   const cardRefs   = useRef<Map<string, HTMLDivElement>>(new Map())
@@ -275,13 +421,13 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
   const myAura     = displayState.auras.find(a => a.side === 'attacker')
   const enemyAura  = displayState.auras.find(a => a.side === 'defender')
 
-  // ── Fetch completo ────────────────────────────────────────────────────────
+  // ── Fetch all turns at once ────────────────────────────────────────────────
   useEffect(() => {
     if (initialState.status === 'completed') {
       setFetching(false)
       if (!completedRef.current) {
         completedRef.current = true
-        setTimeout(() => onComplete(initialState.winnerId !== null), 3000)
+        setTimeout(() => onComplete(initialState.winnerId !== null, rewardsRef.current), 3000)
       }
       return
     }
@@ -296,6 +442,12 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
         finalStateRef.current = data.state as BattleState
         snapshotsRef.current  = data.snapshots as TurnSnapshot[]
         baseSlotsRef.current  = (data.state as BattleState).slots
+        if (data.mmrDelta !== undefined) {
+          rewardsRef.current = {
+            mmrDelta: data.mmrDelta, newMmr: data.newMmr, rank: data.rank,
+            goldEarned: data.goldEarned, weeklyPvpWins: data.weeklyPvpWins,
+          }
+        }
         setSnapshots(data.snapshots)
         setFetching(false)
         setStep(0)
@@ -303,7 +455,7 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
       .catch(() => setError('Error al cargar la batalla.'))
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── Loop de animación paso a paso ─────────────────────────────────────────
+  // ── Step-by-step animation loop ───────────────────────────────────────────
   useEffect(() => {
     if (fetching || step < 0) return
     const snaps = snapshotsRef.current
@@ -318,24 +470,59 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
       setDisplayState(prev => applySnapshot(prev, snap))
       setCurrentLog(prev => [...prev, snap.logEntry])
 
+      // Active ability card — Phase 2
+      const actorBase = baseSlotsRef.current[snap.actorIndex]
+      setActiveAbility({
+        abilityId:   snap.logEntry.abilityId,
+        abilityName: snap.logEntry.abilityName,
+        archetype:   actorBase?.archetype ?? 'forestal',
+        actorName:   snap.logEntry.actorName,
+        resultLines: resultLines(snap.logEntry),
+      })
+
+      // Float damage numbers — Phase 3
       const isStun    = snap.logEntry.abilityId === 'stun'
       const hasTarget = snap.logEntry.targetIds.length > 0 && !isStun
       const isHeal    = hasTarget && snap.logEntry.results[0]?.heal !== undefined
-      const actorBase = baseSlotsRef.current[snap.actorIndex]
+
+      if (hasTarget) {
+        const newFloats = new Map<string, FloatNum[]>()
+        for (const result of snap.logEntry.results) {
+          let label = ''
+          let color = 'text-red-400'
+          if (result.damage !== undefined) {
+            label = result.blocked ? `✦${result.damage}` : `${result.damage}`
+            color = result.blocked ? 'text-amber-400' : 'text-red-400'
+          } else if (result.heal !== undefined) {
+            label = `+${result.heal}`
+            color = 'text-emerald-400'
+          } else if (result.stun) {
+            label = '😵'
+            color = 'text-purple-400'
+          }
+          if (label) {
+            const id = ++floatCounter
+            const prev = newFloats.get(result.targetId) ?? []
+            newFloats.set(result.targetId, [...prev, { id, therianId: result.targetId, label, color }])
+          }
+        }
+        setFloatNums(newFloats)
+        setTimeout(() => setFloatNums(new Map()), 1200)
+      }
 
       setAnimInfo(hasTarget && actorBase ? {
         actorId:   actorBase.therianId,
         targetIds: snap.logEntry.targetIds,
         actorSide: actorBase.side,
         isHeal,
-        frame: step,
+        frame:     step,
       } : null)
 
       const next = step + 1
       if (next >= snaps.length) {
         if (!completedRef.current) {
           completedRef.current = true
-          setTimeout(() => onComplete(snap.winnerId !== null), 2500)
+          setTimeout(() => onComplete(snap.winnerId !== null, rewardsRef.current), 2500)
         }
       } else {
         setStep(next)
@@ -344,7 +531,7 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
     return () => clearTimeout(timer)
   }, [step, fetching, speedIdx]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── WAAPI: cruce real hacia el objetivo ───────────────────────────────────
+  // ── WAAPI: avatar lunges toward target ────────────────────────────────────
   useEffect(() => {
     if (!animInfo) return
     const { actorId, targetIds, actorSide, isHeal } = animInfo
@@ -352,26 +539,21 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
     const actorCardEl = cardRefs.current.get(actorId)
     const avatarEl    = avatarRefs.current.get(actorId)
 
-    // Elevar z-index de la card atacante para que cruce por encima de las demás
+    // Elevate z-index so the card crosses above siblings
     if (actorCardEl) {
       actorCardEl.style.position = 'relative'
       actorCardEl.style.zIndex   = '50'
       setTimeout(() => { if (actorCardEl) actorCardEl.style.zIndex = '' }, 750)
-    }
-
-    // Flash blanco en la card atacante (señal visual de "está atacando")
-    if (actorCardEl) {
       actorCardEl.animate(
         [
-          { boxShadow: '0 0 0 2px rgba(255,255,255,0.7), 0 0 20px rgba(255,255,255,0.3)', offset: 0    },
-          { boxShadow: '0 0 0 1px rgba(255,255,255,0.2)',                                  offset: 0.40 },
-          { boxShadow: 'none',                                                              offset: 1    },
+          { boxShadow: '0 0 0 2px rgba(255,255,255,0.7), 0 0 20px rgba(255,255,255,0.3)', offset: 0 },
+          { boxShadow: '0 0 0 1px rgba(255,255,255,0.2)', offset: 0.40 },
+          { boxShadow: 'none', offset: 1 },
         ],
         { duration: 450 },
       )
     }
 
-    // Calcular destino del avatar hacia el centro promedio de los objetivos
     const animDuration = isHeal ? 520 : 680
     if (avatarEl && targetIds.length > 0) {
       const sourceRect = avatarEl.getBoundingClientRect()
@@ -390,28 +572,25 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
         const dx   = targetCx - sourceCx
         const dy   = targetCy - sourceCy
         const dist = Math.hypot(dx, dy)
-
-        // Detenerse 22px antes del centro del objetivo (para no solaparse)
         const reach = dist > 44 ? (dist - 22) / dist : 0.5
         const fx    = dx * reach
         const fy    = dy * reach
-
-        const rot = actorSide === 'attacker' ? 14 : -14
+        const rot   = actorSide === 'attacker' ? 14 : -14
 
         avatarEl.animate(
           [
-            { transform: 'translate(0,0) scale(1) rotate(0deg)',                                                                  offset: 0    },
-            { transform: `translate(${fx*.78}px,${fy*.78}px) scale(${isHeal?1.1:1.22}) rotate(${isHeal?4:rot}deg)`,              offset: 0.30 },
-            { transform: `translate(${fx}px,${fy}px) scale(${isHeal?1.06:0.82}) rotate(${isHeal?0:rot*-.55}deg)`,                offset: 0.50 },
-            { transform: `translate(${fx*.42}px,${fy*.42}px) scale(1.06) rotate(0deg)`,                                          offset: 0.72 },
-            { transform: 'translate(0,0) scale(1) rotate(0deg)',                                                                  offset: 1    },
+            { transform: 'translate(0,0) scale(1) rotate(0deg)',                                                                   offset: 0    },
+            { transform: `translate(${fx*.78}px,${fy*.78}px) scale(${isHeal?1.1:1.22}) rotate(${isHeal?4:rot}deg)`,               offset: 0.30 },
+            { transform: `translate(${fx}px,${fy}px) scale(${isHeal?1.06:0.82}) rotate(${isHeal?0:rot*-.55}deg)`,                 offset: 0.50 },
+            { transform: `translate(${fx*.42}px,${fy*.42}px) scale(1.06) rotate(0deg)`,                                           offset: 0.72 },
+            { transform: 'translate(0,0) scale(1) rotate(0deg)',                                                                   offset: 1    },
           ],
           { duration: animDuration, easing: 'cubic-bezier(0.25,0.46,0.45,0.94)' },
         )
       }
     }
 
-    // Flash/shake en objetivos — sincronizados con la llegada del avatar (offset 0.50)
+    // Flash + shake on target cards
     const impactDelay = Math.round(animDuration * 0.46)
     for (const targetId of targetIds) {
       const cardEl = cardRefs.current.get(targetId)
@@ -420,34 +599,32 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
       if (isHeal) {
         cardEl.animate(
           [
-            { boxShadow: 'none',                                                                      offset: 0    },
-            { boxShadow: 'inset 0 0 0 2px rgba(52,211,153,0.95),0 0 26px rgba(52,211,153,0.65)',     offset: 0.28 },
-            { boxShadow: 'inset 0 0 0 1px rgba(52,211,153,0.3)',                                     offset: 0.65 },
-            { boxShadow: 'none',                                                                      offset: 1    },
+            { boxShadow: 'none', offset: 0 },
+            { boxShadow: 'inset 0 0 0 2px rgba(52,211,153,0.95),0 0 26px rgba(52,211,153,0.65)', offset: 0.28 },
+            { boxShadow: 'inset 0 0 0 1px rgba(52,211,153,0.3)', offset: 0.65 },
+            { boxShadow: 'none', offset: 1 },
           ],
           { duration: 620, delay: impactDelay },
         )
       } else {
-        // Flash rojo
         cardEl.animate(
           [
-            { boxShadow: 'none',                                                                             offset: 0    },
-            { boxShadow: 'inset 0 0 0 2px rgba(239,68,68,0.95),0 0 26px rgba(239,68,68,0.75)',              offset: 0.22 },
-            { boxShadow: 'inset 0 0 0 1px rgba(239,68,68,0.3)',                                              offset: 0.58 },
-            { boxShadow: 'none',                                                                             offset: 1    },
+            { boxShadow: 'none', offset: 0 },
+            { boxShadow: 'inset 0 0 0 2px rgba(239,68,68,0.95),0 0 26px rgba(239,68,68,0.75)', offset: 0.22 },
+            { boxShadow: 'inset 0 0 0 1px rgba(239,68,68,0.3)', offset: 0.58 },
+            { boxShadow: 'none', offset: 1 },
           ],
           { duration: 560, delay: impactDelay },
         )
-        // Shake
         cardEl.animate(
           [
-            { transform: 'translateX(0)',                offset: 0    },
+            { transform: 'translateX(0)',               offset: 0    },
             { transform: 'translateX(-9px) rotate(-2deg)', offset: 0.14 },
             { transform: 'translateX(9px) rotate(2deg)',  offset: 0.28 },
             { transform: 'translateX(-5px)',               offset: 0.44 },
             { transform: 'translateX(5px)',                offset: 0.60 },
             { transform: 'translateX(-2px)',               offset: 0.80 },
-            { transform: 'translateX(0)',                offset: 1    },
+            { transform: 'translateX(0)',               offset: 1    },
           ],
           { duration: 460, delay: impactDelay + 20 },
         )
@@ -455,7 +632,7 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
     }
   }, [animInfo]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── Skip ──────────────────────────────────────────────────────────────────
+  // ── Skip to end ───────────────────────────────────────────────────────────
   function handleSkip() {
     if (fetching) return
     const snaps = snapshotsRef.current
@@ -465,10 +642,11 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
     setCurrentLog(snaps.map(s => s.logEntry))
     setActorIndex(last.actorIndex)
     setAnimInfo(null)
+    setFloatNums(new Map())
     setStep(snaps.length)
     if (!completedRef.current) {
       completedRef.current = true
-      setTimeout(() => onComplete(last.winnerId !== null), 1500)
+      setTimeout(() => onComplete(last.winnerId !== null, rewardsRef.current), 1500)
     }
   }
 
@@ -491,10 +669,20 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
   const won = displayState.winnerId !== null
 
   return (
-    <div className="space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
+    <div className="space-y-3">
+      {/* Float number keyframe */}
+      <style>{`
+        @keyframes floatUp {
+          0%   { opacity: 1; transform: translateY(0)    scale(1);    }
+          60%  { opacity: 1; transform: translateY(-36px) scale(1.15); }
+          100% { opacity: 0; transform: translateY(-60px) scale(0.85); }
+        }
+      `}</style>
+
+      {/* ── Header ── */}
+      <div className="flex items-center justify-between gap-2">
         <span className="text-white/40 text-xs">Ronda {displayState.round}</span>
+
         <span className={`text-xs px-2 py-0.5 rounded-full border ${
           fetching
             ? 'border-white/20 bg-white/5 text-white/40 animate-pulse'
@@ -504,94 +692,117 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
         }`}>
           {fetching ? '⏳ Cargando...' : isFinished ? '✅ Resuelta' : `⚔️ ${step + 1}/${snapshots.length}`}
         </span>
-        <span className="text-white/30 text-xs">⚔️ PvP</span>
+
+        {/* Speed + skip controls */}
+        {!fetching && !isFinished && (
+          <div className="flex items-center gap-1">
+            {SPEED_OPTIONS.map((opt, i) => (
+              <button
+                key={opt.label}
+                onClick={() => setSpeedIdx(i)}
+                className={`text-xs px-1.5 py-0.5 rounded border transition-all ${
+                  speedIdx === i
+                    ? 'border-white/40 bg-white/10 text-white/80'
+                    : 'border-white/10 bg-white/3 text-white/30 hover:border-white/20 hover:text-white/50'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+            <button
+              onClick={handleSkip}
+              className="text-xs px-1.5 py-0.5 rounded border border-white/10 bg-white/3 text-white/30 hover:border-white/20 hover:text-white/50 transition-all ml-0.5"
+            >
+              ⏭
+            </button>
+          </div>
+        )}
       </div>
 
-      {/* Progreso */}
+      {/* Progress bar */}
       {!fetching && snapshots.length > 0 && (
         <div className="h-0.5 bg-white/5 rounded-full overflow-hidden">
           <div className="h-full bg-white/20 transition-all duration-500" style={{ width: `${progress}%` }} />
         </div>
       )}
 
-      {/* Cola de turnos */}
-      <div className="bg-white/3 border border-white/5 rounded-xl p-3">
-        <p className="text-white/25 text-[10px] text-center mb-2 uppercase tracking-widest">Orden de turno</p>
-        <TurnQueueBar slots={displayState.slots} turnIndex={displayState.turnIndex} actorIndex={actorIndex} />
+      {/* ── Phase 1: Arena ── */}
+      <div className="relative rounded-2xl border border-white/8 bg-[#080810] overflow-visible">
+        {/* Atmospheric side glows */}
+        <div className="absolute inset-0 pointer-events-none rounded-2xl overflow-hidden">
+          <div className="absolute left-0 top-0 bottom-0 w-1/2 bg-gradient-to-r from-blue-900/15 to-transparent" />
+          <div className="absolute right-0 top-0 bottom-0 w-1/2 bg-gradient-to-l from-red-900/15 to-transparent" />
+        </div>
+
+        {/* Aura name badges */}
+        {(myAura || enemyAura) && (
+          <div className="relative flex justify-between px-3 pt-2 pb-0 gap-2">
+            {myAura
+              ? <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-white/5 border border-white/10 text-white/30">{getAuraLabel(myAura)}</span>
+              : <span />}
+            {enemyAura
+              ? <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-white/5 border border-white/10 text-white/30">{getAuraLabel(enemyAura)}</span>
+              : <span />}
+          </div>
+        )}
+
+        {/* Characters face-to-face */}
+        <div className="relative flex items-start gap-1 px-2 py-3">
+          {/* Attacker column */}
+          <div className="flex flex-col gap-2 flex-1 min-w-0">
+            <p className="text-[9px] text-white/20 uppercase tracking-widest text-center">Tu equipo</p>
+            {mySlots.map(slot => (
+              <ArenaSlot
+                key={slot.therianId}
+                slot={slot}
+                isActor={displayState.slots.indexOf(slot) === actorIndex}
+                isNext={displayState.slots.indexOf(slot) === displayState.turnIndex}
+                onCardRef={makeCardRefFn(slot.therianId)}
+                onAvatarRef={makeAvatarRefFn(slot.therianId)}
+                mirrored={false}
+                floats={floatNums.get(slot.therianId) ?? []}
+              />
+            ))}
+          </div>
+
+          {/* VS center divider */}
+          <div className="flex flex-col items-center justify-center self-stretch pt-7 gap-1 px-0.5 flex-shrink-0">
+            <div className="w-px flex-1 bg-gradient-to-b from-transparent via-white/8 to-transparent" />
+            <span className="text-white/15 text-[9px] font-black tracking-widest">VS</span>
+            <div className="w-px flex-1 bg-gradient-to-b from-transparent via-white/8 to-transparent" />
+          </div>
+
+          {/* Defender column (avatars mirrored) */}
+          <div className="flex flex-col gap-2 flex-1 min-w-0">
+            <p className="text-[9px] text-white/20 uppercase tracking-widest text-center">Rival</p>
+            {enemySlots.map(slot => (
+              <ArenaSlot
+                key={slot.therianId}
+                slot={slot}
+                isActor={displayState.slots.indexOf(slot) === actorIndex}
+                isNext={displayState.slots.indexOf(slot) === displayState.turnIndex}
+                onCardRef={makeCardRefFn(slot.therianId)}
+                onAvatarRef={makeAvatarRefFn(slot.therianId)}
+                mirrored={true}
+                floats={floatNums.get(slot.therianId) ?? []}
+              />
+            ))}
+          </div>
+        </div>
       </div>
 
-      {/* Arena — grid 2 columnas */}
-      <div className="grid grid-cols-2 gap-3">
-        {/* Tu equipo */}
-        <div className="space-y-2">
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-white/50 text-xs font-medium">Tu equipo</span>
-            {myAura && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-white/5 border border-white/10 text-white/35" title={(myAura as any).auraId}>
-                {getAuraLabel(myAura)}
-              </span>
-            )}
-          </div>
-          {mySlots.map(slot => (
-            <SlotCard
-              key={slot.therianId}
-              slot={slot}
-              isActor={displayState.slots.indexOf(slot) === actorIndex}
-              isNext={displayState.slots.indexOf(slot) === displayState.turnIndex}
-              onCardRef={makeCardRefFn(slot.therianId)}
-              onAvatarRef={makeAvatarRefFn(slot.therianId)}
-            />
-          ))}
-        </div>
-
-        {/* Rival */}
-        <div className="space-y-2">
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-white/50 text-xs font-medium">Rival</span>
-            {enemyAura && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-white/5 border border-white/10 text-white/35" title={(enemyAura as any).auraId}>
-                {getAuraLabel(enemyAura)}
-              </span>
-            )}
-          </div>
-          {enemySlots.map(slot => (
-            <SlotCard
-              key={slot.therianId}
-              slot={slot}
-              isActor={displayState.slots.indexOf(slot) === actorIndex}
-              isNext={displayState.slots.indexOf(slot) === displayState.turnIndex}
-              onCardRef={makeCardRefFn(slot.therianId)}
-              onAvatarRef={makeAvatarRefFn(slot.therianId)}
-            />
-          ))}
-        </div>
+      {/* ── Turn queue ── */}
+      <div className="bg-white/3 border border-white/5 rounded-xl px-3 py-2">
+        <p className="text-white/20 text-[9px] text-center mb-1.5 uppercase tracking-widest">Orden de turno</p>
+        <TurnQueueBar
+          slots={displayState.slots}
+          turnIndex={displayState.turnIndex}
+          actorIndex={actorIndex}
+        />
       </div>
 
-      {/* Controles de velocidad */}
-      {!fetching && !isFinished && (
-        <div className="flex items-center justify-center gap-2">
-          <span className="text-white/25 text-xs">Vel:</span>
-          {SPEED_OPTIONS.map((opt, i) => (
-            <button
-              key={opt.label}
-              onClick={() => setSpeedIdx(i)}
-              className={`text-xs px-2 py-1 rounded-lg border transition-all ${
-                speedIdx === i
-                  ? 'border-white/40 bg-white/10 text-white/80'
-                  : 'border-white/10 bg-white/3 text-white/30 hover:border-white/20 hover:text-white/50'
-              }`}
-            >
-              {opt.label}
-            </button>
-          ))}
-          <button
-            onClick={handleSkip}
-            className="text-xs px-2 py-1 rounded-lg border border-white/10 bg-white/3 text-white/30 hover:border-white/20 hover:text-white/50 transition-all ml-1"
-          >
-            ⏭ Skip
-          </button>
-        </div>
-      )}
+      {/* ── Phase 2: Active ability card ── */}
+      {!fetching && <ActiveAbilityCard info={activeAbility} />}
 
       {/* Error */}
       {error && (
@@ -600,28 +811,24 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
         </p>
       )}
 
-      {/* Log */}
+      {/* Compact combat log */}
       {currentLog.length > 0 && (
         <div className="bg-white/3 border border-white/5 rounded-xl p-3 space-y-1.5">
-          <p className="text-white/25 text-[10px] uppercase tracking-widest mb-2">Registro</p>
-          {[...currentLog].reverse().slice(0, 5).map((entry, i) => (
+          <p className="text-white/20 text-[9px] uppercase tracking-widest mb-1.5">Registro</p>
+          {[...currentLog].reverse().slice(0, 4).map((entry, i) => (
             <LogLine key={currentLog.length - 1 - i} entry={entry} isNew={i === 0} />
           ))}
         </div>
       )}
 
-      {/* ── Pantalla de resultado ── */}
+      {/* Result overlay */}
       {isFinished && displayState.status === 'completed' && (
-        <div
-          className={`result-reveal text-center py-8 rounded-2xl border-2 space-y-3 ${
-            won
-              ? 'border-amber-500/50 bg-gradient-to-b from-amber-500/10 to-amber-500/5 shadow-[0_0_40px_rgba(252,211,77,0.15)]'
-              : 'border-red-500/40  bg-gradient-to-b from-red-500/10  to-red-500/5  shadow-[0_0_40px_rgba(239,68,68,0.12)]'
-          }`}
-        >
-          <div className="icon-pop text-6xl leading-none">
-            {won ? '🏆' : '💀'}
-          </div>
+        <div className={`text-center py-8 rounded-2xl border-2 space-y-3 ${
+          won
+            ? 'border-amber-500/50 bg-gradient-to-b from-amber-500/10 to-amber-500/5 shadow-[0_0_40px_rgba(252,211,77,0.15)]'
+            : 'border-red-500/40  bg-gradient-to-b from-red-500/10  to-red-500/5  shadow-[0_0_40px_rgba(239,68,68,0.12)]'
+        }`}>
+          <div className="text-6xl leading-none">{won ? '🏆' : '💀'}</div>
           <div>
             <p className={`text-2xl font-bold ${won ? 'text-amber-300' : 'text-red-300'}`}>
               {won ? '¡Victoria!' : 'Derrota'}

--- a/components/pvp/BattleField.tsx
+++ b/components/pvp/BattleField.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
-import type { BattleState, TurnSlot, TurnSnapshot, ActionLogEntry, AvatarSnapshot } from '@/lib/pvp/types'
+import type { BattleState, TurnSlot, TurnSnapshot, ActionLogEntry, AvatarSnapshot, Aura } from '@/lib/pvp/types'
 import type { Ability } from '@/lib/pvp/types'
 import { ABILITY_BY_ID } from '@/lib/pvp/abilities'
+import { getAuraById } from '@/lib/catalogs/auras'
 import TherianAvatar from '@/components/TherianAvatar'
 import type { TherianDTO } from '@/lib/therian-dto'
 
@@ -49,14 +50,24 @@ interface ActiveAbilityInfo {
 export function describeAbility(ab: Ability): string {
   const e = ab.effect
   const parts: string[] = []
-  if (e.damage  !== undefined) parts.push(`Daño base ×${e.damage}`)
-  if (e.heal    !== undefined) parts.push(`Curación base ×${e.heal}`)
-  if (e.stun    !== undefined) parts.push(`Aturde ${e.stun} turno${e.stun !== 1 ? 's' : ''}`)
-  if (e.buff)    parts.push(`+${Math.round(e.buff.pct * 100)}% ${e.buff.stat} por ${e.buff.turns} turnos`)
-  if (e.debuff)  parts.push(`${Math.round(e.debuff.pct * 100)}% ${e.debuff.stat} por ${e.debuff.turns} turnos`)
-  if (e.reflect) parts.push(`Refleja ${Math.round(e.reflect * 100)}% del daño recibido`)
-  if (e.damageReduction) parts.push(`Reduce ${Math.round(e.damageReduction * 100)}% el daño recibido`)
-  if (e.tiebreaker) parts.push('Actúa primero en empates de velocidad')
+  if (e.damage     !== undefined) parts.push(`Daño base ×${e.damage}`)
+  if (e.heal       !== undefined) parts.push(`Curación base ×${e.heal}`)
+  if (e.stun       !== undefined) parts.push(`Aturde ${e.stun} turno${e.stun !== 1 ? 's' : ''}`)
+  if (e.stunChance !== undefined) parts.push(`${Math.round(e.stunChance * 100)}% chance de aturdir`)
+  if (e.dot)                      parts.push(`Veneno: ×${e.dot.damage} daño por ${e.dot.turns} turnos`)
+  if (e.shield     !== undefined) parts.push(`Escudo: ${e.shield} HP`)
+  if (e.lifeSteal  !== undefined) parts.push(`Roba vida ${Math.round(e.lifeSteal * 100)}%`)
+  if (e.multiHit)                 parts.push(`${e.multiHit.count} golpes consecutivos`)
+  if (e.execute)                  parts.push(`Ejecuta si HP < ${Math.round(e.execute.threshold * 100)}%`)
+  if (e.buff)                     parts.push(`+${Math.round(e.buff.pct * 100)}% ${e.buff.stat} por ${e.buff.turns} turnos`)
+  if (e.debuff)                   parts.push(`-${Math.round(e.debuff.pct * 100)}% ${e.debuff.stat} por ${e.debuff.turns} turnos`)
+  if (e.thorns     !== undefined) parts.push(`Refleja ${Math.round(e.thorns * 100)}% del daño recibido`)
+  if (e.damageReduction !== undefined) parts.push(`Reduce ${Math.round(e.damageReduction * 100)}% el daño recibido`)
+  if (e.regen      !== undefined) parts.push(`Regenera ${e.regen} HP/turno`)
+  if (e.critBoost  !== undefined) parts.push(`+${Math.round(e.critBoost * 100)}% daño crítico`)
+  if (e.immunity)                 parts.push(`Inmune a ${e.immunity === 'debuff' ? 'debuffs' : e.immunity}`)
+  if (e.endure)                   parts.push('Sobrevive un golpe fatal con 1 HP')
+  if (e.tiebreaker)               parts.push('Actúa primero en empates de velocidad')
   return parts.join('. ')
 }
 
@@ -87,10 +98,12 @@ export function resultLines(entry: ActionLogEntry): string[] {
 export function applySnapshot(base: BattleState, snap: TurnSnapshot): BattleState {
   return {
     ...base,
-    turnIndex: snap.turnIndex,
-    round:     snap.round,
-    status:    snap.status,
-    winnerId:  snap.winnerId,
+    turnIndex:  snap.turnIndex,
+    round:      snap.round,
+    status:     snap.status,
+    winnerId:   snap.winnerId,
+    ...(snap.frontliner ? { frontliner: snap.frontliner } : {}),
+    ...(snap.phase      ? { phase:      snap.phase      } : {}),
     slots: base.slots.map(slot => {
       const s = snap.slots.find(ss => ss.therianId === slot.therianId)
       if (!s) return slot
@@ -108,6 +121,17 @@ const ARCH_META = {
   volcanico: { emoji: '🔥', border: 'border-orange-500/50',  text: 'text-orange-400',  bg: 'bg-orange-500/15'  },
 } as const
 
+// Raw CSS values for inline styles (not Tailwind classes)
+const ARCH_COLORS: Record<string, { glow: string; ring: string; textColor: string; bgLight: string }> = {
+  forestal:  { glow: 'rgba(52,211,153,0.38)',  ring: 'rgba(52,211,153,0.80)',  textColor: '#34D399', bgLight: 'rgba(52,211,153,0.10)' },
+  electrico: { glow: 'rgba(250,204,21,0.38)',  ring: 'rgba(250,204,21,0.80)',  textColor: '#FBBF24', bgLight: 'rgba(250,204,21,0.10)' },
+  acuatico:  { glow: 'rgba(96,165,250,0.38)',  ring: 'rgba(96,165,250,0.80)',  textColor: '#60A5FA', bgLight: 'rgba(96,165,250,0.10)' },
+  volcanico: { glow: 'rgba(251,146,60,0.38)',  ring: 'rgba(251,146,60,0.80)',  textColor: '#FB923C', bgLight: 'rgba(251,146,60,0.10)' },
+}
+function archColors(archetype: string) {
+  return ARCH_COLORS[archetype] ?? ARCH_COLORS.forestal
+}
+
 function archMeta(archetype: string) {
   return ARCH_META[archetype as keyof typeof ARCH_META] ?? ARCH_META.forestal
 }
@@ -122,8 +146,8 @@ function getAuraLabel(aura: { name?: string; type?: string }): string {
 }
 
 const SPEED_OPTIONS = [
-  { label: '1×', ms: 1600 },
-  { label: '2×', ms: 800  },
+  { label: '1×', ms: 2200 },
+  { label: '2×', ms: 900  },
   { label: '4×', ms: 350  },
 ]
 
@@ -132,12 +156,16 @@ let floatCounter = 0
 
 // ─── SlotAvatar ───────────────────────────────────────────────────────────────
 
-function SlotAvatar({ slot }: { slot: TurnSlot }) {
+function SlotAvatar({ slot, size = 88 }: { slot: TurnSlot; size?: number }) {
   const snap: AvatarSnapshot | undefined = slot.avatarSnapshot
   const meta = archMeta(slot.archetype)
 
   if (!snap) {
-    return <div className="w-16 h-16 flex items-center justify-center text-4xl">{meta.emoji}</div>
+    return (
+      <div style={{ width: size, height: size }} className="flex items-center justify-center text-5xl">
+        {meta.emoji}
+      </div>
+    )
   }
 
   const fakeDto = {
@@ -155,7 +183,7 @@ function SlotAvatar({ slot }: { slot: TurnSlot }) {
     canBite: false, nextBiteAt: null, status: 'active', createdAt: '',
   } as unknown as TherianDTO
 
-  return <TherianAvatar therian={fakeDto} size={64} />
+  return <TherianAvatar therian={fakeDto} size={size} />
 }
 
 // ─── HpBar ────────────────────────────────────────────────────────────────────
@@ -166,6 +194,337 @@ function HpBar({ current, max }: { current: number; max: number }) {
   return (
     <div className="h-1.5 bg-white/10 rounded-full overflow-hidden">
       <div className={`h-full ${color} transition-all duration-700`} style={{ width: `${pct}%` }} />
+    </div>
+  )
+}
+
+// ─── TeamChipBar ──────────────────────────────────────────────────────────────
+
+function TeamChipBar({ slots, actorId, spotlightTargetId }: {
+  slots: TurnSlot[]
+  actorId: string | null
+  spotlightTargetId: string | null
+}) {
+  return (
+    <div style={{ display:'flex', alignItems:'center', justifyContent:'center', gap:5 }}>
+      {slots.map((slot) => {
+        const colors  = archColors(slot.archetype)
+        const isActor = slot.therianId === actorId
+        const isTgt   = slot.therianId === spotlightTargetId
+        const hpPct   = slot.maxHp > 0 ? Math.max(0, slot.currentHp / slot.maxHp) : 0
+        const hpColor = hpPct > 0.55 ? '#10B981' : hpPct > 0.28 ? '#F59E0B' : '#EF4444'
+        return (
+          <div key={slot.therianId} style={{
+            position:'relative', width:34, height:34, borderRadius:'50%', flexShrink:0,
+            border:`2px solid ${isActor ? colors.ring : isTgt ? 'rgba(239,68,68,0.75)' : 'rgba(255,255,255,0.10)'}`,
+            background: slot.isDead ? 'rgba(255,255,255,0.03)' : colors.bgLight,
+            display:'flex', alignItems:'center', justifyContent:'center',
+            opacity: slot.isDead ? 0.28 : 1,
+            filter: slot.isDead ? 'grayscale(1)' : 'none',
+            boxShadow: isActor ? `0 0 10px ${colors.ring}` : isTgt ? '0 0 10px rgba(239,68,68,0.55)' : 'none',
+            transition:'all 0.35s ease',
+          }}>
+            <span style={{ fontSize:15, lineHeight:1 }}>{archMeta(slot.archetype).emoji}</span>
+            {/* Mini HP bar at bottom of chip */}
+            <div style={{ position:'absolute', bottom:2, left:4, right:4, height:2, borderRadius:2, background:'rgba(0,0,0,0.4)', overflow:'hidden' }}>
+              <div style={{ height:'100%', width:`${hpPct*100}%`, background:hpColor, borderRadius:2, transition:'width 0.6s ease' }} />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ─── PortraitBar ──────────────────────────────────────────────────────────────
+
+function PortraitBar({ slots, activeSlotId, label, labelColor, direction = 'row', onSwitch, switchCooldownEnd, canSwitch, bypassCooldown }: {
+  slots:             TurnSlot[]
+  activeSlotId:      string | null
+  label:             string
+  labelColor:        string
+  direction?:        'row' | 'column'
+  onSwitch?:         (therianId: string) => void
+  switchCooldownEnd?: number | null
+  canSwitch?:        boolean
+  bypassCooldown?:   boolean
+}) {
+  const [now, setNow] = useState(Date.now())
+  useEffect(() => {
+    if (!switchCooldownEnd || switchCooldownEnd <= Date.now()) return
+    const t = setInterval(() => setNow(Date.now()), 250)
+    return () => clearInterval(t)
+  }, [switchCooldownEnd])
+
+  const remaining  = switchCooldownEnd ? Math.max(0, Math.ceil((switchCooldownEnd - now) / 1000)) : 0
+  const inCooldown = remaining > 0 && !bypassCooldown
+
+  return (
+    <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap:4 }}>
+      <span style={{ fontSize:8, color:labelColor, fontWeight:700, textTransform:'uppercase', letterSpacing:1.2 }}>{label}</span>
+      <div style={{ display:'flex', flexDirection: direction === 'column' ? 'column' : 'row', gap: direction === 'column' ? 6 : 5 }}>
+        {slots.map(slot => {
+          const colors    = archColors(slot.archetype)
+          const hpPct     = slot.maxHp > 0 ? Math.max(0, slot.currentHp / slot.maxHp) : 0
+          const hpColor   = hpPct > 0.55 ? '#10B981' : hpPct > 0.28 ? '#F59E0B' : '#EF4444'
+          const isActive  = slot.therianId === activeSlotId
+          const isBench   = !isActive && !slot.isDead
+          const clickable = isBench && !!onSwitch && !!canSwitch && !inCooldown
+          return (
+            <div key={slot.therianId} style={{ display:'flex', flexDirection:'column', alignItems:'center', gap:3 }}>
+              {/* Active indicator dot */}
+              <div style={{
+                width:5, height:5, borderRadius:'50%',
+                background: isActive && !slot.isDead ? '#FFFFFF' : 'transparent',
+                boxShadow: isActive && !slot.isDead ? '0 0 6px rgba(255,255,255,0.9)' : 'none',
+              }} />
+              {/* Portrait circle */}
+              <div
+                onClick={() => { if (clickable) onSwitch!(slot.therianId) }}
+                title={clickable ? `Cambiar a ${slot.name ?? slot.archetype}` : undefined}
+                style={{
+                  width:46, height:46, borderRadius:'50%', overflow:'hidden', flexShrink:0,
+                  border:`2px solid ${
+                    isActive && !slot.isDead ? colors.ring
+                      : slot.isDead ? 'rgba(255,255,255,0.06)'
+                      : clickable ? colors.ring.replace('0.80','0.55')
+                      : 'rgba(255,255,255,0.12)'
+                  }`,
+                  background: slot.isDead ? 'rgba(0,0,0,0.40)' : colors.bgLight,
+                  display:'flex', alignItems:'center', justifyContent:'center',
+                  opacity: slot.isDead ? 0.35 : 1,
+                  filter: slot.isDead ? 'grayscale(1)' : 'none',
+                  boxShadow: isActive && !slot.isDead
+                    ? `0 0 14px ${colors.ring}, 0 0 5px ${colors.glow}`
+                    : clickable ? `0 0 12px ${colors.glow.replace('0.38','0.30')}` : 'none',
+                  transition:'all 0.25s ease',
+                  position:'relative',
+                  cursor: clickable ? 'pointer' : 'default',
+                  transform: clickable ? 'scale(1.06)' : 'scale(1)',
+                }}>
+                <SlotAvatar slot={slot} size={44} />
+                {slot.isDead && (
+                  <div style={{ position:'absolute', inset:0, display:'flex', alignItems:'center', justifyContent:'center', fontSize:16, background:'rgba(0,0,0,0.45)', borderRadius:'50%' }}>💀</div>
+                )}
+                {/* Cooldown countdown overlay on bench portraits */}
+                {isBench && inCooldown && (
+                  <div style={{
+                    position:'absolute', inset:0, display:'flex', alignItems:'center', justifyContent:'center',
+                    background:'rgba(0,0,0,0.68)', borderRadius:'50%',
+                    fontSize:15, fontWeight:900, color:'rgba(255,255,255,0.88)',
+                    textShadow:'0 0 8px rgba(255,255,255,0.5)',
+                    pointerEvents:'none',
+                  }}>
+                    {remaining}
+                  </div>
+                )}
+              </div>
+              {/* HP bar */}
+              <div style={{ width:46, height:3, background:'rgba(255,255,255,0.08)', borderRadius:2, overflow:'hidden' }}>
+                <div style={{ height:'100%', width:`${hpPct*100}%`, background:hpColor, borderRadius:2, transition:'width 0.6s ease' }} />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ─── AbilityCardsRow ──────────────────────────────────────────────────────────
+
+function AbilityCardsRow({ slot, onInspect, inspectedAbilityId }: {
+  slot:               TurnSlot | null
+  onInspect:          (id: string | null) => void
+  inspectedAbilityId: string | null
+}) {
+  if (!slot || slot.equippedAbilities.length === 0) return null
+  return (
+    <div style={{ display:'flex', gap:6 }}>
+      {slot.equippedAbilities.slice(0, 4).map(id => {
+        const ab    = ABILITY_BY_ID[id]
+        if (!ab) return null
+        const theme = ARCH_CARD_THEME[ab.archetype] ?? DEFAULT_CARD_THEME
+        const abMeta = archMeta(ab.archetype)
+        const isAct  = inspectedAbilityId === id
+        return (
+          <button
+            key={id}
+            onClick={() => onInspect(isAct ? null : id)}
+            title={describeAbility(ab)}
+            style={{
+              flex:'1 1 0', minWidth:0,
+              background: isAct ? theme.cardBg : 'rgba(255,255,255,0.03)',
+              border:`1.5px solid ${isAct ? theme.borderColor : 'rgba(255,255,255,0.08)'}`,
+              borderRadius:10, padding:'9px 6px', cursor:'pointer', textAlign:'center',
+              transform: isAct ? 'translateY(-3px) scale(1.04)' : 'translateY(0) scale(1)',
+              boxShadow: isAct ? `0 0 18px ${theme.glowColor}` : 'none',
+              transition:'all 0.18s ease',
+              display:'flex', flexDirection:'column', alignItems:'center', gap:5,
+            }}
+          >
+            <span style={{ fontSize:22, lineHeight:1 }}>{abMeta.emoji}</span>
+            <span style={{
+              fontSize:9, fontWeight:700, lineHeight:1.2, textAlign:'center',
+              color: isAct ? theme.textColor : 'rgba(255,255,255,0.55)',
+              overflow:'hidden', whiteSpace:'nowrap', textOverflow:'ellipsis', maxWidth:'100%',
+            }}>
+              {ab.name}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+// ─── SpotlightSlot ────────────────────────────────────────────────────────────
+
+function SpotlightSlot({ slot, side, onCardRef, onAvatarRef, floats, onInspect, inspectedAbilityId }: {
+  slot:               TurnSlot
+  side:               'left' | 'right'   // left=attacker, right=target — controls facing
+  onCardRef:          (el: HTMLDivElement | null) => void
+  onAvatarRef:        (el: HTMLDivElement | null) => void
+  floats:             FloatNum[]
+  onInspect:          (id: string | null) => void
+  inspectedAbilityId: string | null
+}) {
+  const colors  = archColors(slot.archetype)
+  const meta    = archMeta(slot.archetype)
+  const hpPct   = slot.maxHp > 0 ? Math.max(0, slot.currentHp / slot.maxHp) : 0
+  const hpColor = hpPct > 0.55 ? '#10B981' : hpPct > 0.28 ? '#F59E0B' : '#EF4444'
+  // left side faces right (normal); right side faces left (mirrored)
+  const mirrored = side === 'right'
+  const [hoveredAbilityId, setHoveredAbilityId] = useState<string | null>(null)
+
+  return (
+    <div
+      ref={onCardRef}
+      style={{
+        display:'flex', flexDirection:'column', alignItems:'center',
+        flex:1, minWidth:0, maxWidth:'46%',
+        opacity: slot.isDead ? 0.32 : 1,
+        filter:  slot.isDead ? 'grayscale(0.85)' : 'none',
+        transition:'opacity 0.4s ease, filter 0.4s ease',
+      }}
+    >
+      {/* Archetype tag */}
+      <div style={{ fontSize:9, fontWeight:700, textTransform:'uppercase', letterSpacing:1.5, color:colors.textColor, opacity:0.75, marginBottom:4 }}>
+        {meta.emoji} {slot.archetype}
+      </div>
+
+      {/* Name */}
+      <div style={{ fontSize:13, fontWeight:800, color:'rgba(255,255,255,0.92)', marginBottom:5, textAlign:'center', maxWidth:'100%', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap', textShadow:`0 0 12px ${colors.glow}` }}>
+        {slot.name ?? slot.archetype}
+      </div>
+
+      {/* HP numbers */}
+      <div style={{ display:'flex', alignItems:'baseline', gap:3, marginBottom:5 }}>
+        <span style={{ fontSize:16, fontWeight:900, color:hpColor, lineHeight:1 }}>{slot.currentHp}</span>
+        <span style={{ fontSize:10, color:'rgba(255,255,255,0.22)' }}>/{slot.maxHp}</span>
+        {/* Active effects */}
+        {slot.effects.map((e, i) => (
+          <span key={i} style={{ fontSize:12 }}>
+            {e.type === 'stun' ? '😵' : e.type === 'buff' ? '⬆' : '⬇'}
+          </span>
+        ))}
+      </div>
+
+      {/* HP bar */}
+      <div style={{ width:'85%', height:5, background:'rgba(255,255,255,0.07)', borderRadius:4, marginBottom:10, overflow:'hidden' }}>
+        <div style={{ height:'100%', width:`${hpPct*100}%`, background:hpColor, borderRadius:4, transition:'width 0.7s ease, background 0.5s ease', boxShadow:`0 0 6px ${hpColor}60` }} />
+      </div>
+
+      {/* Avatar */}
+      <div style={{ position:'relative' }}>
+        {/* Archetype aura ring behind avatar */}
+        <div style={{
+          position:'absolute', inset:-10, borderRadius:'50%',
+          background:`radial-gradient(ellipse, ${colors.glow} 0%, transparent 68%)`,
+          pointerEvents:'none', animation:'arenaGlow 2.4s ease-in-out infinite alternate',
+        }} />
+
+        {/* Float damage numbers */}
+        {floats.length > 0 && (
+          <div style={{ position:'absolute', bottom:'108%', left:'50%', transform:'translateX(-50%)', display:'flex', flexDirection:'column', alignItems:'center', pointerEvents:'none', zIndex:20, gap:2 }}>
+            {floats.map(f => (
+              <span key={f.id} className={`font-extrabold leading-none select-none ${f.color}`}
+                style={{ fontSize:28, animation:'floatUp 1.2s ease-out forwards', textShadow:'0 2px 8px rgba(0,0,0,0.8)' }}>
+                {f.label}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* WAAPI wrapper */}
+        <div ref={onAvatarRef} style={{ willChange:'transform', position:'relative', zIndex:2, transform: mirrored ? 'scaleX(-1)' : 'none' }}>
+          <SlotAvatar slot={slot} size={112} />
+        </div>
+
+        {/* Dead skull */}
+        {slot.isDead && (
+          <div style={{ position:'absolute', inset:0, display:'flex', alignItems:'center', justifyContent:'center', fontSize:40, zIndex:5 }}>💀</div>
+        )}
+      </div>
+
+      {/* Ground shadow / puddle */}
+      <div style={{ width:70, height:10, borderRadius:'50%', background:`radial-gradient(ellipse, ${colors.glow} 0%, transparent 70%)`, marginTop:2, opacity:0.7 }} />
+
+      {/* Ability dots with hover tooltip */}
+      {slot.equippedAbilities.length > 0 && (
+        <div style={{ display:'flex', gap:6, marginTop:8, position:'relative', zIndex:15 }}>
+          {slot.equippedAbilities.slice(0,4).map(id => {
+            const ab     = ABILITY_BY_ID[id]
+            if (!ab) return null
+            const abMeta = archMeta(ab.archetype)
+            const abClr  = archColors(ab.archetype)
+            const isHov  = hoveredAbilityId === id
+            const desc   = describeAbility(ab)
+            return (
+              <div key={id} style={{ position:'relative' }}>
+                {/* Hover tooltip (floats upward, stays inside arena) */}
+                {isHov && (
+                  <div style={{
+                    position:'absolute', bottom:'calc(100% + 10px)', left:'50%', transform:'translateX(-50%)',
+                    minWidth:148, maxWidth:200, zIndex:50, pointerEvents:'none',
+                    background:'linear-gradient(145deg,#0C0C1E,#14142A)',
+                    border:`1px solid ${abClr.ring.replace('0.80','0.50')}`,
+                    borderRadius:10, padding:'8px 10px',
+                    boxShadow:`0 0 18px ${abClr.glow}, 0 4px 14px rgba(0,0,0,0.75)`,
+                  }}>
+                    <div style={{ display:'flex', alignItems:'center', gap:5, marginBottom:4 }}>
+                      <span style={{ fontSize:14 }}>{abMeta.emoji}</span>
+                      <span style={{ fontSize:11, fontWeight:700, color:'rgba(255,255,255,0.92)', lineHeight:1.2 }}>{ab.name}</span>
+                    </div>
+                    {desc && (
+                      <p style={{ margin:0, fontSize:9, color:'rgba(255,255,255,0.52)', lineHeight:1.55 }}>{desc}</p>
+                    )}
+                  </div>
+                )}
+                {/* Dot button */}
+                <button
+                  onMouseEnter={() => setHoveredAbilityId(id)}
+                  onMouseLeave={() => setHoveredAbilityId(null)}
+                  onClick={() => onInspect(inspectedAbilityId === id ? null : id)}
+                  style={{
+                    width:28, height:28, borderRadius:'50%',
+                    border:`1.5px solid ${abClr.ring.replace('0.80', isHov ? '0.70' : '0.40')}`,
+                    background: isHov ? abClr.bgLight.replace('0.10','0.22') : abClr.bgLight,
+                    fontSize:13, cursor:'pointer',
+                    display:'flex', alignItems:'center', justifyContent:'center',
+                    transform: isHov ? 'scale(1.25)' : 'scale(1)',
+                    transition:'all 0.15s ease',
+                    boxShadow: isHov ? `0 0 10px ${abClr.ring}` : 'none',
+                  }}
+                  aria-label={ab.name}
+                >
+                  {abMeta.emoji}
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }
@@ -212,44 +571,56 @@ function TurnQueueBar({ slots, turnIndex, actorIndex }: {
 
 // ─── ArenaSlot ────────────────────────────────────────────────────────────────
 
-function ArenaSlot({ slot, isActor, isNext, onCardRef, onAvatarRef, mirrored, floats }: {
-  slot:        TurnSlot
-  isActor:     boolean
-  isNext:      boolean
-  onCardRef:   (el: HTMLDivElement | null) => void
-  onAvatarRef: (el: HTMLDivElement | null) => void
-  mirrored:    boolean
-  floats:      FloatNum[]
+function ArenaSlot({ slot, isActor, isNext, onCardRef, onAvatarRef, mirrored, floats, onInspect, inspectedAbilityId, avatarSize = 88 }: {
+  slot:               TurnSlot
+  isActor:            boolean
+  isNext:             boolean
+  onCardRef:          (el: HTMLDivElement | null) => void
+  onAvatarRef:        (el: HTMLDivElement | null) => void
+  mirrored:           boolean
+  floats:             FloatNum[]
+  onInspect:          (id: string | null) => void
+  inspectedAbilityId: string | null
+  avatarSize?:        number
 }) {
   const meta = archMeta(slot.archetype)
 
-  const borderClass = slot.isDead
-    ? 'border-white/5 bg-white/2'
-    : isActor
-      ? `${meta.border} ${meta.bg} ring-2 ring-white/50 shadow-[0_0_14px_rgba(255,255,255,0.08)]`
-      : isNext
-        ? `${meta.border} bg-white/5 ring-1 ring-white/15`
-        : 'border-white/10 bg-white/3'
+  // Glow color per archetype for active turn
+  const glowColor = {
+    forestal:  '0_0_18px_rgba(52,211,153,0.55)',
+    electrico: '0_0_18px_rgba(250,204,21,0.55)',
+    acuatico:  '0_0_18px_rgba(96,165,250,0.55)',
+    volcanico: '0_0_18px_rgba(251,146,60,0.55)',
+  }[slot.archetype] ?? '0_0_18px_rgba(255,255,255,0.4)'
 
   return (
     <div
       ref={onCardRef}
-      className={`relative rounded-xl border p-2 transition-all duration-500 ${borderClass} ${slot.isDead ? 'opacity-30 grayscale' : ''}`}
+      className={`relative flex flex-col items-center transition-all duration-400 ${slot.isDead ? 'opacity-30 grayscale' : ''}`}
     >
-      {/* HP bar + text */}
-      <HpBar current={slot.currentHp} max={slot.maxHp} />
-      <div className="flex justify-between items-center mt-0.5 mb-1.5">
-        <span className="text-[9px] text-white/30">{slot.currentHp}/{slot.maxHp}</span>
-        {slot.effects.length > 0 && (
-          <span className="text-[10px]">
-            {slot.effects.map(e => e.type === 'stun' ? '😵' : e.type === 'buff' ? '↑' : '↓').join('')}
+      {/* ── Name + HP bar (above avatar) ── */}
+      <div className="w-full px-1 mb-1.5 space-y-0.5">
+        <div className="flex items-center justify-between gap-1">
+          <span className="text-[9px] font-semibold text-white/55 truncate leading-none">
+            {slot.name ?? slot.archetype}
           </span>
-        )}
+          <div className="flex items-center gap-0.5 flex-shrink-0">
+            {slot.effects.map((e, i) => (
+              <span key={i} className="text-[9px] leading-none">
+                {e.type === 'stun' ? '😵' : e.type === 'buff' ? '↑' : '↓'}
+              </span>
+            ))}
+            <span className="text-[9px] text-white/35 font-mono leading-none ml-0.5">
+              {slot.currentHp}
+            </span>
+          </div>
+        </div>
+        <HpBar current={slot.currentHp} max={slot.maxHp} />
       </div>
 
-      {/* Avatar with float numbers — outer div for float anchor */}
+      {/* ── Avatar ── */}
       <div className="relative flex justify-center">
-        {/* Float numbers — absolute above avatar, not mirrored */}
+        {/* Float damage numbers */}
         {floats.length > 0 && (
           <div
             className="absolute inset-x-0 flex flex-col items-center pointer-events-none"
@@ -258,7 +629,7 @@ function ArenaSlot({ slot, isActor, isNext, onCardRef, onAvatarRef, mirrored, fl
             {floats.map(f => (
               <span
                 key={f.id}
-                className={`text-sm font-extrabold leading-none select-none ${f.color}`}
+                className={`text-base font-extrabold leading-none select-none ${f.color}`}
                 style={{ animation: 'floatUp 1.2s ease-out forwards' }}
               >
                 {f.label}
@@ -267,45 +638,60 @@ function ArenaSlot({ slot, isActor, isNext, onCardRef, onAvatarRef, mirrored, fl
           </div>
         )}
 
-        {/* WAAPI wrapper — translated by animation, does NOT have mirror so dx/dy are correct */}
-        <div ref={onAvatarRef} style={{ willChange: 'transform' }}>
-          {/* Mirror applied only to the visual content */}
-          <div style={{ transform: mirrored ? 'scaleX(-1)' : 'none' }}
-               className={slot.isDead ? 'opacity-30' : ''}>
-            <SlotAvatar slot={slot} />
+        {/* Active turn glow ring */}
+        {isActor && !slot.isDead && (
+          <div
+            className="absolute inset-0 rounded-full pointer-events-none"
+            style={{ boxShadow: `0 0 0 2px rgba(255,255,255,0.5), ${glowColor.replace(/_/g,' ')}`, zIndex: 1 }}
+          />
+        )}
+        {/* Next turn subtle ring */}
+        {isNext && !isActor && !slot.isDead && (
+          <div className="absolute inset-0 rounded-full pointer-events-none ring-1 ring-white/20" style={{ zIndex: 1 }} />
+        )}
+
+        {/* WAAPI wrapper */}
+        <div ref={onAvatarRef} style={{ willChange: 'transform', position: 'relative', zIndex: 2 }}>
+          <div style={{ transform: mirrored ? 'scaleX(-1)' : 'none' }}>
+            <SlotAvatar slot={slot} size={avatarSize} />
           </div>
         </div>
+
+        {/* Turn badge (⚔ floats above avatar) */}
+        {isActor && !slot.isDead && (
+          <div className="absolute -top-3 left-1/2 -translate-x-1/2 z-10 text-white text-xs font-black animate-bounce"
+               style={{ animationDuration: '0.7s' }}>
+            ⚔
+          </div>
+        )}
       </div>
 
-      {/* Name */}
-      <p className="text-[10px] text-center text-white/60 mt-1.5 truncate font-medium">
-        {slot.name ?? slot.archetype}
-      </p>
+      {/* ── Ground shadow ── */}
+      <div className="w-14 h-1.5 rounded-full bg-black/30 blur-sm mt-0.5" />
 
-      {/* Equipped ability dots (Phase 4: hover to inspect) */}
+      {/* ── Ability dots ── */}
       {slot.equippedAbilities.length > 0 && (
         <div className="flex justify-center gap-1 mt-1.5">
           {slot.equippedAbilities.slice(0, 4).map(id => {
             const ab = ABILITY_BY_ID[id]
             if (!ab) return null
             const abMeta = archMeta(ab.archetype)
+            const isActive = inspectedAbilityId === id
             return (
-              <div
+              <button
                 key={id}
-                className={`w-4 h-4 rounded-full border flex items-center justify-center text-[8px] leading-none cursor-default ${abMeta.border} ${abMeta.bg} hover:scale-125 transition-transform`}
-                title={`${ab.name}: ${describeAbility(ab)}`}
+                onClick={() => onInspect(isActive ? null : id)}
+                className={`w-6 h-6 rounded-full border flex items-center justify-center text-[10px] leading-none transition-all active:scale-90 ${
+                  isActive
+                    ? `${abMeta.border} ${abMeta.bg} ring-2 ring-white/60 scale-110`
+                    : `${abMeta.border} ${abMeta.bg} opacity-75 hover:opacity-100 hover:scale-110`
+                }`}
+                aria-label={ab.name}
               >
                 {abMeta.emoji}
-              </div>
+              </button>
             )
           })}
-        </div>
-      )}
-
-      {/* Actor turn indicator badge */}
-      {isActor && !slot.isDead && (
-        <div className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-white flex items-center justify-center shadow-lg">
-          <span className="text-[9px] font-black text-black leading-none">⚔</span>
         </div>
       )}
     </div>
@@ -368,6 +754,180 @@ function ActiveAbilityCard({ info }: { info: ActiveAbilityInfo | null }) {
   )
 }
 
+// ─── AbilityInspectorPanel — TCG Card style ───────────────────────────────────
+
+const ARCH_CARD_THEME: Record<string, {
+  cardBg: string; borderColor: string; glowColor: string; textColor: string; badgeBg: string
+}> = {
+  forestal:  { cardBg:'linear-gradient(145deg,#041A0E 0%,#072816 45%,#041A0E 100%)', borderColor:'rgba(52,211,153,0.50)',  glowColor:'rgba(52,211,153,0.14)',  textColor:'#34D399', badgeBg:'rgba(52,211,153,0.14)'  },
+  electrico: { cardBg:'linear-gradient(145deg,#161200 0%,#241D00 45%,#161200 100%)', borderColor:'rgba(250,204,21,0.50)',  glowColor:'rgba(250,204,21,0.14)',  textColor:'#FBBF24', badgeBg:'rgba(250,204,21,0.14)'  },
+  acuatico:  { cardBg:'linear-gradient(145deg,#020C1A 0%,#051626 45%,#020C1A 100%)', borderColor:'rgba(96,165,250,0.50)',  glowColor:'rgba(96,165,250,0.14)',  textColor:'#60A5FA', badgeBg:'rgba(96,165,250,0.14)'  },
+  volcanico: { cardBg:'linear-gradient(145deg,#180500 0%,#260A00 45%,#180500 100%)', borderColor:'rgba(251,146,60,0.50)',  glowColor:'rgba(251,146,60,0.14)',  textColor:'#FB923C', badgeBg:'rgba(251,146,60,0.14)'  },
+}
+const DEFAULT_CARD_THEME = {
+  cardBg:'linear-gradient(145deg,#0D0D20 0%,#16162E 45%,#0D0D20 100%)',
+  borderColor:'rgba(255,255,255,0.18)', glowColor:'rgba(255,255,255,0.06)', textColor:'rgba(255,255,255,0.7)', badgeBg:'rgba(255,255,255,0.08)',
+}
+
+function AbilityInspectorPanel({ abilityId, onClose }: { abilityId: string; onClose: () => void }) {
+  const ab = ABILITY_BY_ID[abilityId]
+  if (!ab) return null
+
+  const meta  = archMeta(ab.archetype)
+  const theme = ARCH_CARD_THEME[ab.archetype] ?? DEFAULT_CARD_THEME
+  const desc  = describeAbility(ab)
+
+  // Type badge
+  let typeLabel = 'EFECTO';  let typeBg = 'rgba(245,158,11,0.22)'; let typeClr = '#F59E0B'
+  if (ab.type === 'passive')            { typeLabel='PASIVO'; typeBg='rgba(168,85,247,0.22)';  typeClr='#A855F7' }
+  else if (ab.effect.heal !== undefined) { typeLabel='CURA';   typeBg='rgba(52,211,153,0.22)';  typeClr='#34D399' }
+  else if (ab.effect.damage !== undefined){ typeLabel='ATAQUE'; typeBg='rgba(248,113,113,0.22)'; typeClr='#F87171' }
+
+  // Effect chips
+  const chips: { label: string; color: string }[] = []
+  const e = ab.effect
+  if (e.damage     !== undefined) chips.push({ label:`×${e.damage} daño`,                                           color:'#F87171' })
+  if (e.heal       !== undefined) chips.push({ label:`×${e.heal} curación`,                                         color:'#34D399' })
+  if (e.stun       !== undefined) chips.push({ label:`Aturde ${e.stun}t`,                                           color:'#C084FC' })
+  if (e.buff)                     chips.push({ label:`+${Math.round(e.buff.pct*100)}% ${e.buff.stat} ×${e.buff.turns}t`,     color:'#60A5FA' })
+  if (e.debuff)                   chips.push({ label:`-${Math.round(e.debuff.pct*100)}% ${e.debuff.stat} ×${e.debuff.turns}t`, color:'#FB923C' })
+  if (e.reflect)                  chips.push({ label:`Refleja ${Math.round(e.reflect*100)}%`,                       color:'#22D3EE' })
+  if (e.damageReduction)          chips.push({ label:`-${Math.round(e.damageReduction*100)}% daño`,                 color:'#2DD4BF' })
+  if (e.tiebreaker)               chips.push({ label:'Prioridad turno',                                             color:'#FCD34D' })
+
+  return (
+    <div style={{
+      background: theme.cardBg,
+      border: `1.5px solid ${theme.borderColor}`,
+      borderRadius: 16,
+      boxShadow: `0 0 28px ${theme.glowColor}, 0 8px 24px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.05)`,
+      padding: '14px 16px',
+      position: 'relative',
+      overflow: 'hidden',
+    }}>
+      {/* Background watermark */}
+      <div style={{
+        position:'absolute', right:10, top:'50%', transform:'translateY(-50%)',
+        fontSize:90, opacity:0.05, pointerEvents:'none', lineHeight:1, userSelect:'none',
+      }}>
+        {meta.emoji}
+      </div>
+
+      {/* Top gloss line */}
+      <div style={{ position:'absolute', top:0, left:16, right:16, height:1, background:'rgba(255,255,255,0.08)', borderRadius:1 }} />
+
+      {/* ── Header ── */}
+      <div style={{ display:'flex', alignItems:'flex-start', justifyContent:'space-between', gap:10, marginBottom:10 }}>
+        <div style={{ display:'flex', alignItems:'center', gap:10, flex:1, minWidth:0 }}>
+          {/* Archetype icon box */}
+          <div style={{
+            width:38, height:38, borderRadius:10, flexShrink:0,
+            border:`1px solid ${theme.borderColor}`,
+            background:'rgba(255,255,255,0.04)',
+            display:'flex', alignItems:'center', justifyContent:'center',
+            fontSize:20, boxShadow:`0 0 10px ${theme.glowColor}`,
+          }}>
+            {meta.emoji}
+          </div>
+          <div style={{ minWidth:0, flex:1 }}>
+            {/* Name + type */}
+            <div style={{ display:'flex', alignItems:'center', gap:7, flexWrap:'wrap', marginBottom:3 }}>
+              <span style={{ color:'rgba(255,255,255,0.92)', fontWeight:700, fontSize:14, lineHeight:1 }}>
+                {ab.name}
+              </span>
+              <span style={{
+                fontSize:9, fontWeight:800, padding:'2px 7px', borderRadius:20,
+                background:typeBg, color:typeClr, border:`1px solid ${typeClr}38`,
+                letterSpacing:0.8, textTransform:'uppercase',
+              }}>
+                {typeLabel}
+              </span>
+            </div>
+            {/* Archetype label */}
+            <span style={{ fontSize:9, color:theme.textColor, opacity:0.65, textTransform:'uppercase', letterSpacing:1.2 }}>
+              {ab.archetype}
+            </span>
+          </div>
+        </div>
+        {/* Close */}
+        <button
+          onClick={onClose}
+          style={{
+            width:26, height:26, borderRadius:8, flexShrink:0,
+            background:'rgba(255,255,255,0.05)', border:'1px solid rgba(255,255,255,0.10)',
+            color:'rgba(255,255,255,0.35)', fontSize:13, cursor:'pointer',
+            display:'flex', alignItems:'center', justifyContent:'center',
+          }}
+          aria-label="Cerrar"
+        >✕</button>
+      </div>
+
+      {/* ── Divider ── */}
+      <div style={{ height:1, background:theme.borderColor, opacity:0.35, marginBottom:10 }} />
+
+      {/* ── Effect chips ── */}
+      {chips.length > 0 && (
+        <div style={{ display:'flex', flexWrap:'wrap', gap:5, marginBottom:10 }}>
+          {chips.map((c, i) => (
+            <span key={i} style={{
+              fontSize:11, fontWeight:600, padding:'3px 9px', borderRadius:20,
+              background:'rgba(255,255,255,0.05)', border:'1px solid rgba(255,255,255,0.09)',
+              color:c.color,
+            }}>
+              {c.label}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* ── Description ── */}
+      <p style={{ margin:0, fontSize:12, color:'rgba(255,255,255,0.50)', lineHeight:1.65, fontStyle:'italic' }}>
+        &ldquo;{desc || 'Habilidad de efecto especial.'}&rdquo;
+      </p>
+    </div>
+  )
+}
+
+// ─── AuraLabel with hover tooltip ────────────────────────────────────────────
+
+function AuraLabel({ aura, side }: { aura: Aura; side: 'attacker' | 'defender' }) {
+  const [hovered, setHovered] = useState(false)
+  const auraDef   = getAuraById(aura.auraId)
+  const isAtk     = side === 'attacker'
+  const clr       = isAtk ? 'rgba(96,165,250,' : 'rgba(248,113,113,'
+
+  return (
+    <div style={{ position:'relative' }} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
+      <span style={{
+        fontSize:8, cursor:'help',
+        color:`${clr}0.65)`, background:`${clr}0.08)`,
+        border:`1px solid ${clr}0.20)`, borderRadius:10,
+        padding:'2px 7px', display:'block', textAlign:'center',
+        maxWidth:58, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap', lineHeight:1.5,
+      }}>
+        {getAuraLabel(aura)}
+      </span>
+      {hovered && (
+        <div style={{
+          position:'absolute', top:'calc(100% + 6px)', left:'50%', transform:'translateX(-50%)',
+          minWidth:200, maxWidth:260, zIndex:100, pointerEvents:'none',
+          background:'linear-gradient(145deg,#0D0D20,#16162E)',
+          border:`1px solid ${clr}0.35)`,
+          borderRadius:12, padding:'10px 12px',
+          boxShadow:`0 0 24px ${clr}0.18), 0 8px 24px rgba(0,0,0,0.6)`,
+        }}>
+          <div style={{ fontSize:11, fontWeight:700, color:'rgba(255,255,255,0.92)', marginBottom:5, letterSpacing:0.5 }}>
+            {auraDef?.name ?? getAuraLabel(aura)}
+          </div>
+          <p style={{ margin:0, fontSize:10, color:'rgba(255,255,255,0.55)', lineHeight:1.6, fontStyle:'italic' }}>
+            {auraDef?.description ?? '—'}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ─── LogLine ──────────────────────────────────────────────────────────────────
 
 function LogLine({ entry, isNew }: { entry: ActionLogEntry; isNew: boolean }) {
@@ -393,18 +953,247 @@ function LogLine({ entry, isNew }: { entry: ActionLogEntry; isNew: boolean }) {
 
 // ─── Main Component ───────────────────────────────────────────────────────────
 
+// ─── ManualAbilityPanel ───────────────────────────────────────────────────────
+
+function ManualAbilityPanel({ slot, onUse, disabled, cooldowns }: {
+  slot:      import('@/lib/pvp/types').TurnSlot
+  onUse:     (abilityId: string, targetId?: string) => void
+  disabled:  boolean
+  cooldowns: Record<string, number>
+}) {
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const allAbilities = [slot.innateAbilityId, ...slot.equippedAbilities.slice(0, 4)]
+  const selectedAb = selectedId ? ABILITY_BY_ID[selectedId] : null
+
+  function handleSelect(id: string) {
+    if (disabled) return
+    if ((cooldowns[id] ?? 0) > 0) return
+    setSelectedId(prev => prev === id ? null : id)
+  }
+
+  function handleConfirm() {
+    if (!selectedId || disabled) return
+    onUse(selectedId)
+    setSelectedId(null)
+  }
+
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap:8 }}>
+      <div style={{ fontSize:9, color:'rgba(255,255,255,0.35)', textTransform:'uppercase', letterSpacing:1.2, textAlign:'center' }}>
+        ⚔ Tu turno — elige habilidad
+      </div>
+
+      {/* Ability grid */}
+      <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:5 }}>
+        {allAbilities.map(id => {
+          const ab = ABILITY_BY_ID[id]
+          if (!ab) return null
+          const meta  = archMeta(ab.archetype)
+          const clr   = archColors(ab.archetype)
+          const cd    = cooldowns[id] ?? 0
+          const isDisabled = disabled || cd > 0
+          const isSelected = selectedId === id
+          return (
+            <button
+              key={id}
+              onClick={() => handleSelect(id)}
+              disabled={isDisabled}
+              style={{
+                display:'flex', flexDirection:'column', alignItems:'center', gap:4,
+                padding:'8px 6px', borderRadius:12,
+                background: isSelected
+                  ? clr.bgLight.replace('0.10', '0.22')
+                  : isDisabled ? 'rgba(255,255,255,0.02)' : clr.bgLight,
+                border:`1.5px solid ${isSelected ? clr.ring : isDisabled ? 'rgba(255,255,255,0.06)' : clr.ring.replace('0.80','0.35')}`,
+                cursor: isDisabled ? 'not-allowed' : 'pointer',
+                opacity: isDisabled ? 0.45 : 1,
+                transition:'all 0.15s ease',
+                boxShadow: isSelected
+                  ? `0 0 18px ${clr.glow}, inset 0 0 0 1px ${clr.ring.replace('0.80','0.25')}`
+                  : isDisabled ? 'none' : `0 0 8px ${clr.glow.replace('0.38','0.18')}`,
+                position:'relative',
+                transform: isSelected ? 'scale(1.04)' : 'scale(1)',
+              }}
+            >
+              <span style={{ fontSize:18 }}>{meta.emoji}</span>
+              <span style={{ fontSize:10, fontWeight:700, color: isDisabled ? 'rgba(255,255,255,0.30)' : isSelected ? clr.textColor : 'rgba(255,255,255,0.65)', textAlign:'center', lineHeight:1.3 }}>
+                {ab.name}
+              </span>
+              {ab.type === 'passive' && (
+                <span style={{ fontSize:8, color:'rgba(255,255,255,0.30)', fontStyle:'italic' }}>pasivo</span>
+              )}
+              {cd > 0 && (
+                <span style={{ position:'absolute', top:4, right:6, fontSize:9, color:'rgba(255,255,255,0.40)', fontWeight:700 }}>
+                  {cd}t
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Selected ability card + confirm */}
+      {selectedAb && (() => {
+        const meta  = archMeta(selectedAb.archetype)
+        const clr   = archColors(selectedAb.archetype)
+        const desc  = describeAbility(selectedAb)
+        let typeLabel = 'EFECTO'; let typeClr = '#F59E0B'
+        if (selectedAb.type === 'passive')               { typeLabel='PASIVO'; typeClr='#A855F7' }
+        else if (selectedAb.effect.heal !== undefined)   { typeLabel='CURA';   typeClr='#34D399' }
+        else if (selectedAb.effect.damage !== undefined) { typeLabel='ATAQUE'; typeClr='#F87171' }
+        return (
+          <div style={{
+            borderRadius:14, padding:'12px 14px',
+            background:`linear-gradient(135deg, ${clr.bgLight.replace('0.10','0.20')} 0%, rgba(0,0,0,0.3) 100%)`,
+            border:`1.5px solid ${clr.ring.replace('0.80','0.40')}`,
+            boxShadow:`0 0 20px ${clr.glow.replace('0.38','0.12')}`,
+            display:'flex', flexDirection:'column', gap:10,
+          }}>
+            {/* Header */}
+            <div style={{ display:'flex', alignItems:'center', gap:10 }}>
+              <span style={{ fontSize:24, lineHeight:1 }}>{meta.emoji}</span>
+              <div style={{ flex:1, minWidth:0 }}>
+                <div style={{ display:'flex', alignItems:'center', gap:6, flexWrap:'wrap' }}>
+                  <span style={{ color:'rgba(255,255,255,0.92)', fontWeight:700, fontSize:14 }}>{selectedAb.name}</span>
+                  <span style={{ fontSize:9, fontWeight:700, padding:'2px 6px', borderRadius:12, background:'rgba(255,255,255,0.08)', color:typeClr }}>{typeLabel}</span>
+                  {selectedAb.cooldown > 0 && (
+                    <span style={{ fontSize:9, color:'rgba(255,255,255,0.35)', marginLeft:'auto' }}>CD: {selectedAb.cooldown}t</span>
+                  )}
+                </div>
+                {desc && (
+                  <p style={{ fontSize:11, color:'rgba(255,255,255,0.50)', marginTop:3, lineHeight:1.5 }}>{desc}</p>
+                )}
+              </div>
+            </div>
+            {/* Confirm + cancel */}
+            <div style={{ display:'flex', gap:8 }}>
+              <button
+                onClick={handleConfirm}
+                disabled={disabled}
+                style={{
+                  flex:1, padding:'9px 0', borderRadius:10, fontSize:13, fontWeight:700,
+                  background: disabled ? 'rgba(255,255,255,0.05)' : `linear-gradient(135deg, ${clr.bgLight.replace('0.10','0.35')}, ${clr.bgLight.replace('0.10','0.20')})`,
+                  border:`1.5px solid ${disabled ? 'rgba(255,255,255,0.08)' : clr.ring.replace('0.80','0.70')}`,
+                  color: disabled ? 'rgba(255,255,255,0.25)' : clr.textColor,
+                  cursor: disabled ? 'not-allowed' : 'pointer',
+                  boxShadow: disabled ? 'none' : `0 0 16px ${clr.glow}`,
+                  transition:'all 0.15s ease',
+                }}
+              >
+                ⚔ Usar {selectedAb.name}
+              </button>
+              <button
+                onClick={() => setSelectedId(null)}
+                style={{
+                  padding:'9px 14px', borderRadius:10, fontSize:12, fontWeight:500,
+                  background:'rgba(255,255,255,0.03)', border:'1px solid rgba(255,255,255,0.10)',
+                  color:'rgba(255,255,255,0.40)', cursor:'pointer', transition:'all 0.15s ease',
+                }}
+              >
+                ✕
+              </button>
+            </div>
+          </div>
+        )
+      })()}
+    </div>
+  )
+}
+
+// ─── SwitchPanel ──────────────────────────────────────────────────────────────
+
+function SwitchPanel({ benchSlots, onSwitch, disabled, cooldownEnd, forced }: {
+  benchSlots:  import('@/lib/pvp/types').TurnSlot[]
+  onSwitch:    (therianId: string) => void
+  disabled:    boolean
+  cooldownEnd: number | null
+  forced:      boolean  // true = frontliner died, must switch
+}) {
+  const [now, setNow] = useState(Date.now())
+  useEffect(() => {
+    if (!cooldownEnd || cooldownEnd <= Date.now()) return
+    const t = setInterval(() => setNow(Date.now()), 500)
+    return () => clearInterval(t)
+  }, [cooldownEnd])
+
+  const remaining = cooldownEnd ? Math.max(0, Math.ceil((cooldownEnd - now) / 1000)) : 0
+  const canSwitch = !disabled && remaining === 0
+
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap:6 }}>
+      <div style={{ fontSize:9, color: forced ? '#F87171' : 'rgba(255,255,255,0.35)', textTransform:'uppercase', letterSpacing:1.2, textAlign:'center', fontWeight:700 }}>
+        {forced ? '💀 Tu Therian cayó — elige sustituto' : '🔄 Cambiar Therian'}
+      </div>
+      {remaining > 0 && !forced && (
+        <div style={{ textAlign:'center', fontSize:11, color:'rgba(255,255,255,0.40)' }}>
+          Disponible en {remaining}s
+        </div>
+      )}
+      <div style={{ display:'flex', gap:6, justifyContent:'center' }}>
+        {benchSlots.map(slot => {
+          const clr = archColors(slot.archetype)
+          const meta = archMeta(slot.archetype)
+          const hpPct = slot.maxHp > 0 ? Math.max(0, slot.currentHp / slot.maxHp) : 0
+          return (
+            <button
+              key={slot.therianId}
+              onClick={() => canSwitch && onSwitch(slot.therianId)}
+              disabled={!canSwitch}
+              style={{
+                display:'flex', flexDirection:'column', alignItems:'center', gap:4,
+                padding:'10px 14px', borderRadius:14,
+                background: canSwitch ? clr.bgLight : 'rgba(255,255,255,0.02)',
+                border:`1.5px solid ${canSwitch ? clr.ring.replace('0.80','0.60') : 'rgba(255,255,255,0.08)'}`,
+                cursor: canSwitch ? 'pointer' : 'not-allowed',
+                opacity: canSwitch ? 1 : 0.5,
+                transition:'all 0.15s ease',
+                boxShadow: canSwitch ? `0 0 16px ${clr.glow}` : 'none',
+              }}
+            >
+              <span style={{ fontSize:22 }}>{meta.emoji}</span>
+              <span style={{ fontSize:10, fontWeight:700, color:'rgba(255,255,255,0.80)', maxWidth:70, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>
+                {slot.name ?? slot.archetype}
+              </span>
+              {/* HP bar */}
+              <div style={{ width:56, height:3, background:'rgba(255,255,255,0.10)', borderRadius:2, overflow:'hidden' }}>
+                <div style={{ height:'100%', width:`${hpPct*100}%`, background: hpPct>0.55?'#10B981':hpPct>0.28?'#F59E0B':'#EF4444', borderRadius:2 }} />
+              </div>
+              <span style={{ fontSize:9, color:'rgba(255,255,255,0.35)' }}>{slot.currentHp}/{slot.maxHp} HP</span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 export default function BattleField({ battleId, initialState, onComplete }: Props) {
+  const [playerMode, setPlayerMode] = useState<'auto' | 'manual'>('manual')
+  const isManual = playerMode === 'manual'
+
   const [displayState,   setDisplayState]   = useState<BattleState>(initialState)
   const [snapshots,      setSnapshots]      = useState<TurnSnapshot[]>([])
   const [step,           setStep]           = useState(-1)
   const [speedIdx,       setSpeedIdx]       = useState(0)
-  const [fetching,       setFetching]       = useState(true)
+  const [fetching,       setFetching]       = useState(false)  // starts false; auto-fight triggered manually
   const [error,          setError]          = useState<string | null>(null)
   const [currentLog,     setCurrentLog]     = useState<ActionLogEntry[]>([])
   const [actorIndex,     setActorIndex]     = useState(initialState.turnIndex)
-  const [animInfo,       setAnimInfo]       = useState<AnimInfo | null>(null)
-  const [activeAbility,  setActiveAbility]  = useState<ActiveAbilityInfo | null>(null)
-  const [floatNums,      setFloatNums]      = useState<Map<string, FloatNum[]>>(new Map())
+  const [animInfo,            setAnimInfo]            = useState<AnimInfo | null>(null)
+  const [activeAbility,       setActiveAbility]       = useState<ActiveAbilityInfo | null>(null)
+  const [floatNums,           setFloatNums]           = useState<Map<string, FloatNum[]>>(new Map())
+  const [inspectedAbilityId,  setInspectedAbilityId]  = useState<string | null>(null)
+  const [spotlightTargetId,   setSpotlightTargetId]   = useState<string | null>(null)
+  const [showBurst,           setShowBurst]           = useState(false)
+  const [burstType,           setBurstType]           = useState<'damage'|'heal'>('damage')
+  // Manual mode state
+  const [manualWaiting,    setManualWaiting]    = useState(isManual)   // waiting for player input
+  const [manualActing,     setManualActing]     = useState(false)       // sending turn to server
+  const [manualAnimating,  setManualAnimating]  = useState(false)       // playing back snapshots
+  const [showSwitchPanel,  setShowSwitchPanel]  = useState(false)       // show switch UI
+  const [switchCooldownEnd, setSwitchCooldownEnd] = useState<number | null>(null)
+  const [forcedSwitch,      setForcedSwitch]     = useState(false)      // frontliner died, must switch
+  const [attackerSwitchKey, setAttackerSwitchKey] = useState(0)         // increments to trigger switch animation
 
   const finalStateRef = useRef<BattleState>(initialState)
   const snapshotsRef  = useRef<TurnSnapshot[]>([])
@@ -421,16 +1210,41 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
   const myAura     = displayState.auras.find(a => a.side === 'attacker')
   const enemyAura  = displayState.auras.find(a => a.side === 'defender')
 
-  // ── Fetch all turns at once ────────────────────────────────────────────────
-  useEffect(() => {
-    if (initialState.status === 'completed') {
+  // Frontliner slots for 1v1 visual (attacker left, defender right)
+  // Use tracked frontliner IDs from state if available, else fallback to first alive
+  const frontlinerAttackerId = displayState.frontliner?.attacker
+  const frontlinerDefenderId = displayState.frontliner?.defender
+  const activeAttackerSlot = (frontlinerAttackerId
+    ? displayState.slots.find(s => s.therianId === frontlinerAttackerId)
+    : null) ?? mySlots.find(s => !s.isDead) ?? mySlots[0] ?? null
+  const activeDefenderSlot = (frontlinerDefenderId
+    ? displayState.slots.find(s => s.therianId === frontlinerDefenderId)
+    : null) ?? enemySlots.find(s => !s.isDead) ?? enemySlots[0] ?? null
+  const currentActorSlot   = displayState.slots[actorIndex] ?? displayState.slots[0] ?? null
+  const currentTargetSlot  = spotlightTargetId
+    ? (displayState.slots.find(s => s.therianId === spotlightTargetId) ?? null)
+    : null
+  const leftSlot  = (currentActorSlot?.side === 'attacker' ? currentActorSlot : null)
+    ?? (currentTargetSlot?.side === 'attacker' ? currentTargetSlot : null)
+    ?? activeAttackerSlot
+  const rightSlot = (currentActorSlot?.side === 'defender' ? currentActorSlot : null)
+    ?? (currentTargetSlot?.side === 'defender' ? currentTargetSlot : null)
+    ?? activeDefenderSlot
+  const leftColors  = leftSlot  ? archColors(leftSlot.archetype)  : archColors('forestal')
+  const rightColors = rightSlot ? archColors(rightSlot.archetype) : archColors('forestal')
+
+  // ── Run auto-fight (calls /action to resolve all turns) ──────────────────
+  function runAutoFight() {
+    if (displayState.status === 'completed') {
       setFetching(false)
       if (!completedRef.current) {
         completedRef.current = true
-        setTimeout(() => onComplete(initialState.winnerId !== null, rewardsRef.current), 3000)
+        setTimeout(() => onComplete(displayState.winnerId !== null, rewardsRef.current), 3000)
       }
       return
     }
+    setFetching(true)
+    setManualWaiting(false)
     fetch(`/api/pvp/${battleId}/action`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -438,7 +1252,7 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
     })
       .then(r => r.json())
       .then(data => {
-        if (data.error) { setError(data.error); return }
+        if (data.error) { setError(data.error); setFetching(false); return }
         finalStateRef.current = data.state as BattleState
         snapshotsRef.current  = data.snapshots as TurnSnapshot[]
         baseSlotsRef.current  = (data.state as BattleState).slots
@@ -452,8 +1266,11 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
         setFetching(false)
         setStep(0)
       })
-      .catch(() => setError('Error al cargar la batalla.'))
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+      .catch(() => { setError('Error al cargar la batalla.'); setFetching(false) })
+  }
+
+  // ── No auto-fetch on mount — player chooses mode in-battle ────────────────
+  // (intentionally empty — auto-fight is triggered by the mode toggle)
 
   // ── Step-by-step animation loop ───────────────────────────────────────────
   useEffect(() => {
@@ -517,19 +1334,35 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
         isHeal,
         frame:     step,
       } : null)
+      setSpotlightTargetId(snap.logEntry.targetIds[0] ?? null)
 
       const next = step + 1
       if (next >= snaps.length) {
-        if (!completedRef.current) {
-          completedRef.current = true
-          setTimeout(() => onComplete(snap.winnerId !== null, rewardsRef.current), 2500)
+        if (isManual) {
+          // Manual mode: animation done, check next state
+          setManualAnimating(false)
+          const finalState = finalStateRef.current
+          if (finalState.status === 'completed') {
+            if (!completedRef.current) {
+              completedRef.current = true
+              setTimeout(() => onComplete(finalState.winnerId !== null, rewardsRef.current), 2000)
+            }
+          } else if (finalState.phase !== 'waiting_attacker_switch') {
+            // Ready for player's next turn (unless forced switch UI is already shown)
+            if (!showSwitchPanel) setManualWaiting(true)
+          }
+        } else {
+          if (!completedRef.current) {
+            completedRef.current = true
+            setTimeout(() => onComplete(snap.winnerId !== null, rewardsRef.current), 2500)
+          }
         }
       } else {
         setStep(next)
       }
     }, delay)
     return () => clearTimeout(timer)
-  }, [step, fetching, speedIdx]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [step, fetching, speedIdx, isManual, showSwitchPanel]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── WAAPI: avatar lunges toward target ────────────────────────────────────
   useEffect(() => {
@@ -590,8 +1423,12 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
       }
     }
 
-    // Flash + shake on target cards
+    // Central impact burst
     const impactDelay = Math.round(animDuration * 0.46)
+    setBurstType(isHeal ? 'heal' : 'damage')
+    setTimeout(() => { setShowBurst(true); setTimeout(() => setShowBurst(false), 480) }, impactDelay)
+
+    // Flash + shake on target cards
     for (const targetId of targetIds) {
       const cardEl = cardRefs.current.get(targetId)
       if (!cardEl) continue
@@ -632,6 +1469,94 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
     }
   }, [animInfo]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ── Manual mode: play back a batch of snapshots ───────────────────────────
+  function playManualSnapshots(snaps: TurnSnapshot[], finalState: BattleState) {
+    if (snaps.length === 0) return
+    setManualAnimating(true)
+    snapshotsRef.current  = snaps
+    finalStateRef.current = finalState
+    baseSlotsRef.current  = finalState.slots
+    setSnapshots(snaps)
+    setStep(0)
+  }
+
+  // ── Manual mode: send ability ──────────────────────────────────────────────
+  async function handleManualAbility(abilityId: string, targetId?: string) {
+    if (manualActing || manualAnimating) return
+    setManualActing(true)
+    setManualWaiting(false)
+    setError(null)
+    try {
+      const res = await fetch(`/api/pvp/${battleId}/turn`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ abilityId, targetId }),
+      })
+      const data = await res.json()
+      if (data.error) { setError(data.error); setManualWaiting(true); return }
+
+      const newState = data.state as BattleState
+      const snaps    = data.snapshots as TurnSnapshot[]
+      playManualSnapshots(snaps, newState)
+
+      // Check if waiting for player switch after animation
+      if (newState.phase === 'waiting_attacker_switch') {
+        setForcedSwitch(true)
+        setShowSwitchPanel(true)
+      }
+
+      if (newState.status === 'completed') {
+        if (data.mmrDelta !== undefined) {
+          rewardsRef.current = {
+            mmrDelta: data.mmrDelta, newMmr: data.newMmr, rank: data.rank,
+            goldEarned: data.goldEarned, weeklyPvpWins: data.weeklyPvpWins,
+          }
+        }
+      }
+    } catch {
+      setError('Error de conexión.')
+      setManualWaiting(true)
+    } finally {
+      setManualActing(false)
+    }
+  }
+
+  // ── Manual mode: switch frontliner ────────────────────────────────────────
+  async function handleManualSwitch(therianId: string) {
+    if (manualActing || manualAnimating) return
+    setManualActing(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/pvp/${battleId}/switch-frontliner`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ therianId }),
+      })
+      const data = await res.json()
+      if (data.error === 'SWITCH_COOLDOWN') {
+        setSwitchCooldownEnd(Date.now() + (data.remainingMs ?? 10000))
+        setManualActing(false)
+        return
+      }
+      if (data.error) { setError(data.error); setManualActing(false); return }
+
+      const newState = data.state as BattleState
+      if (data.switchCooldownEnd) setSwitchCooldownEnd(data.switchCooldownEnd)
+      setDisplayState(newState)
+      setActorIndex(newState.turnIndex)
+      setAttackerSwitchKey(k => k + 1)
+      setShowSwitchPanel(false)
+      setForcedSwitch(false)
+      if (newState.status !== 'completed') {
+        setManualWaiting(true)
+      }
+    } catch {
+      setError('Error de conexión.')
+    } finally {
+      setManualActing(false)
+    }
+  }
+
   // ── Skip to end ───────────────────────────────────────────────────────────
   function handleSkip() {
     if (fetching) return
@@ -650,8 +1575,10 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
     }
   }
 
-  const isFinished = step >= snapshots.length && !fetching && snapshots.length > 0
-  const progress   = snapshots.length > 0 ? Math.round((Math.max(0, step) / snapshots.length) * 100) : 0
+  const isFinished = isManual
+    ? displayState.status === 'completed'
+    : step >= snapshots.length && !fetching && snapshots.length > 0
+  const progress = snapshots.length > 0 ? Math.round((Math.max(0, step) / snapshots.length) * 100) : 0
 
   function makeCardRefFn(id: string) {
     return (el: HTMLDivElement | null) => {
@@ -670,12 +1597,53 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
 
   return (
     <div className="space-y-3">
-      {/* Float number keyframe */}
+      {/* Keyframes */}
       <style>{`
         @keyframes floatUp {
-          0%   { opacity: 1; transform: translateY(0)    scale(1);    }
-          60%  { opacity: 1; transform: translateY(-36px) scale(1.15); }
-          100% { opacity: 0; transform: translateY(-60px) scale(0.85); }
+          0%   { opacity: 1; transform: translateY(0)     scale(1);    }
+          60%  { opacity: 1; transform: translateY(-40px) scale(1.2);  }
+          100% { opacity: 0; transform: translateY(-68px) scale(0.85); }
+        }
+        @keyframes arenaEntryLeft {
+          from { opacity: 0; transform: translateX(-24px); }
+          to   { opacity: 1; transform: translateX(0);     }
+        }
+        @keyframes arenaEntryRight {
+          from { opacity: 0; transform: translateX(24px); }
+          to   { opacity: 1; transform: translateX(0);    }
+        }
+        @keyframes torchFlicker {
+          0%,100% { opacity:0.95; transform:scaleY(1)    scaleX(1);    }
+          20%     { opacity:0.75; transform:scaleY(0.93) scaleX(1.08); }
+          50%     { opacity:1;   transform:scaleY(1.06) scaleX(0.94); }
+          75%     { opacity:0.82; transform:scaleY(0.96) scaleX(1.05); }
+        }
+        @keyframes torchGlow {
+          0%,100% { opacity:0.55; }
+          50%     { opacity:0.85; }
+        }
+        @keyframes arenaGlow {
+          from { opacity:0.6; transform:scale(0.95); }
+          to   { opacity:1;   transform:scale(1.05); }
+        }
+        @keyframes impactBurst {
+          0%   { opacity:0;   transform:scale(0.2); }
+          25%  { opacity:1;   transform:scale(1.1); }
+          65%  { opacity:0.6; transform:scale(1.4); }
+          100% { opacity:0;   transform:scale(2);   }
+        }
+        @keyframes spotlightEntry {
+          from { opacity:0; transform:translateY(16px) scale(0.92); }
+          to   { opacity:1; transform:translateY(0)    scale(1);    }
+        }
+        @keyframes switchEntryAttacker {
+          0%   { opacity:0; transform:translateX(-38px) scale(0.84); }
+          55%  { opacity:1; transform:translateX(6px)   scale(1.04); }
+          100% { opacity:1; transform:translateX(0)     scale(1);    }
+        }
+        @keyframes spin {
+          from { transform: rotate(0deg); }
+          to   { transform: rotate(360deg); }
         }
       `}</style>
 
@@ -688,35 +1656,60 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
             ? 'border-white/20 bg-white/5 text-white/40 animate-pulse'
             : isFinished
               ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400'
-              : 'border-amber-500/30 bg-amber-500/10 text-amber-400 animate-pulse'
+              : isManual
+                ? manualWaiting
+                  ? 'border-amber-500/30 bg-amber-500/10 text-amber-400'
+                  : 'border-blue-500/30 bg-blue-500/10 text-blue-400 animate-pulse'
+                : 'border-amber-500/30 bg-amber-500/10 text-amber-400 animate-pulse'
         }`}>
-          {fetching ? '⏳ Cargando...' : isFinished ? '✅ Resuelta' : `⚔️ ${step + 1}/${snapshots.length}`}
+          {fetching
+            ? '⏳ Cargando...'
+            : isFinished
+              ? '✅ Resuelta'
+              : isManual
+                ? manualWaiting ? '🎮 Tu turno' : manualActing ? '⏳ Rival...' : '▶ Animando'
+                : `⚔️ ${step + 1}/${snapshots.length}`
+          }
         </span>
 
-        {/* Speed + skip controls */}
-        {!fetching && !isFinished && (
-          <div className="flex items-center gap-1">
-            {SPEED_OPTIONS.map((opt, i) => (
-              <button
-                key={opt.label}
-                onClick={() => setSpeedIdx(i)}
-                className={`text-xs px-1.5 py-0.5 rounded border transition-all ${
-                  speedIdx === i
-                    ? 'border-white/40 bg-white/10 text-white/80'
-                    : 'border-white/10 bg-white/3 text-white/30 hover:border-white/20 hover:text-white/50'
-                }`}
-              >
-                {opt.label}
-              </button>
-            ))}
+        {/* Right controls */}
+        <div className="flex items-center gap-1">
+          {/* Manual mode: "Switch to Auto" button */}
+          {isManual && !isFinished && (manualWaiting || (!manualActing && !manualAnimating)) && (
             <button
-              onClick={handleSkip}
-              className="text-xs px-1.5 py-0.5 rounded border border-white/10 bg-white/3 text-white/30 hover:border-white/20 hover:text-white/50 transition-all ml-0.5"
+              onClick={() => { setPlayerMode('auto'); runAutoFight() }}
+              disabled={fetching || manualActing || manualAnimating}
+              className="text-xs px-2 py-0.5 rounded-lg border border-blue-500/30 bg-blue-500/10 text-blue-400 hover:bg-blue-500/20 hover:border-blue-500/50 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+              title="La IA resolverá el resto de la batalla automáticamente"
             >
-              ⏭
+              🤖 Auto
             </button>
-          </div>
-        )}
+          )}
+          {/* Auto mode: speed + skip controls */}
+          {!fetching && !isFinished && !isManual && (
+            <>
+              {SPEED_OPTIONS.map((opt, i) => (
+                <button
+                  key={opt.label}
+                  onClick={() => setSpeedIdx(i)}
+                  className={`text-xs px-1.5 py-0.5 rounded border transition-all ${
+                    speedIdx === i
+                      ? 'border-white/40 bg-white/10 text-white/80'
+                      : 'border-white/10 bg-white/3 text-white/30 hover:border-white/20 hover:text-white/50'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+              <button
+                onClick={handleSkip}
+                className="text-xs px-1.5 py-0.5 rounded border border-white/10 bg-white/3 text-white/30 hover:border-white/20 hover:text-white/50 transition-all ml-0.5"
+              >
+                ⏭
+              </button>
+            </>
+          )}
+        </div>
       </div>
 
       {/* Progress bar */}
@@ -726,74 +1719,232 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
         </div>
       )}
 
-      {/* ── Phase 1: Arena ── */}
-      <div className="relative rounded-2xl border border-white/8 bg-[#080810] overflow-visible">
-        {/* Atmospheric side glows */}
-        <div className="absolute inset-0 pointer-events-none rounded-2xl overflow-hidden">
-          <div className="absolute left-0 top-0 bottom-0 w-1/2 bg-gradient-to-r from-blue-900/15 to-transparent" />
-          <div className="absolute right-0 top-0 bottom-0 w-1/2 bg-gradient-to-l from-red-900/15 to-transparent" />
+      {/* ══ COLOSSEUM ARENA — Portrait columns flanking arena ══ */}
+      <div style={{ position:'relative', paddingInline:64 }}>
+        {/* Left: player team portraits (outside arena) */}
+        <div style={{ position:'absolute', left:0, top:0, bottom:0, width:64, display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', gap:8 }}>
+          <PortraitBar
+            slots={mySlots}
+            activeSlotId={displayState.frontliner?.attacker ?? leftSlot?.therianId ?? null}
+            label="Tu equipo"
+            labelColor="rgba(96,165,250,0.70)"
+            direction="column"
+            onSwitch={isManual && !manualActing && !manualAnimating ? handleManualSwitch : undefined}
+            switchCooldownEnd={switchCooldownEnd}
+            canSwitch={isManual && (manualWaiting || forcedSwitch) && !manualActing && !manualAnimating}
+            bypassCooldown={forcedSwitch}
+          />
+          {myAura && <AuraLabel aura={myAura} side="attacker" />}
+        </div>
+        {/* Right: enemy team portraits (outside arena) */}
+        <div style={{ position:'absolute', right:0, top:0, bottom:0, width:64, display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', gap:8 }}>
+          <PortraitBar slots={enemySlots} activeSlotId={displayState.frontliner?.defender ?? rightSlot?.therianId ?? null} label="Rival" labelColor="rgba(248,113,113,0.70)" direction="column" />
+          {enemyAura && <AuraLabel aura={enemyAura} side="defender" />}
+        </div>
+      <div
+        className="relative overflow-hidden"
+        style={{ minHeight: 490, background: '#050510', borderRadius: 20, border: '1px solid rgba(120,60,200,0.22)' }}
+      >
+        {/* ── Deep space bg + ceiling glow per side ── */}
+        <div className="absolute inset-0 pointer-events-none" style={{ background:'radial-gradient(ellipse 110% 55% at 50% 0%, #0E0A30 0%, #050510 60%)' }} />
+        <div className="absolute inset-0 pointer-events-none" style={{ background:`radial-gradient(ellipse 60% 48% at 18% 0%, ${leftColors.glow.replace('0.38','0.26')} 0%, transparent 65%)` }} />
+        <div className="absolute inset-0 pointer-events-none" style={{ background:`radial-gradient(ellipse 60% 48% at 82% 0%, ${rightColors.glow.replace('0.38','0.22')} 0%, transparent 65%)` }} />
+
+        {/* ── Crowd silhouettes ── */}
+        <div className="absolute top-0 inset-x-0 pointer-events-none" style={{ height:56, zIndex:2 }}>
+          <svg width="100%" height="56" viewBox="0 0 400 56" preserveAspectRatio="none">
+            {[8,30,52,74,96,118,140,162,184,206,228,250,272,294,316,338,360,382].map((x,i) => (
+              <ellipse key={`b${i}`} cx={x} cy={22} rx={10} ry={16} fill="#08061E" />
+            ))}
+            {[20,46,72,98,124,150,176,202,228,254,280,306,332,358,384].map((x,i) => (
+              <ellipse key={`f${i}`} cx={x} cy={40} rx={13} ry={20} fill="#0A0826" />
+            ))}
+            <rect x="0" y="0" width="400" height="56" fill="url(#cFade)" />
+            <defs>
+              <linearGradient id="cFade" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#050510" stopOpacity="0.55" />
+                <stop offset="100%" stopColor="#050510" stopOpacity="1" />
+              </linearGradient>
+            </defs>
+          </svg>
         </div>
 
-        {/* Aura name badges */}
-        {(myAura || enemyAura) && (
-          <div className="relative flex justify-between px-3 pt-2 pb-0 gap-2">
-            {myAura
-              ? <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-white/5 border border-white/10 text-white/30">{getAuraLabel(myAura)}</span>
-              : <span />}
-            {enemyAura
-              ? <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-white/5 border border-white/10 text-white/30">{getAuraLabel(enemyAura)}</span>
-              : <span />}
-          </div>
-        )}
+        {/* ── Left column + torch ── */}
+        <div className="absolute pointer-events-none" style={{ left:0, top:0, bottom:0, width:38, zIndex:4, background:'linear-gradient(to right,#100E0C,#1A1612,transparent)' }}>
+          <div style={{ position:'absolute', top:76, left:13, width:15, height:6, background:'#2E2418', borderRadius:3 }} />
+          <div style={{ position:'absolute', top:62, left:19, width:4, height:20, background:'#3A2C18', borderRadius:2 }} />
+          <div style={{ position:'absolute', top:42, left:15, width:11, height:22, background:'radial-gradient(ellipse at 50% 85%,#FF5500,#FF3300 40%,transparent 100%)', borderRadius:'50% 50% 35% 35%', animation:'torchFlicker 1.9s ease-in-out infinite' }} />
+          <div style={{ position:'absolute', top:49, left:17, width:7, height:13, background:'radial-gradient(ellipse at 50% 85%,#FFE000,#FFAA00 55%,transparent 100%)', borderRadius:'50% 50% 35% 35%', animation:'torchFlicker 1.4s ease-in-out infinite reverse' }} />
+          <div style={{ position:'absolute', top:32, left:1, width:36, height:52, background:'radial-gradient(ellipse,rgba(255,110,0,0.32),transparent 70%)', animation:'torchGlow 1.9s ease-in-out infinite' }} />
+        </div>
 
-        {/* Characters face-to-face */}
-        <div className="relative flex items-start gap-1 px-2 py-3">
-          {/* Attacker column */}
-          <div className="flex flex-col gap-2 flex-1 min-w-0">
-            <p className="text-[9px] text-white/20 uppercase tracking-widest text-center">Tu equipo</p>
-            {mySlots.map(slot => (
-              <ArenaSlot
-                key={slot.therianId}
-                slot={slot}
-                isActor={displayState.slots.indexOf(slot) === actorIndex}
-                isNext={displayState.slots.indexOf(slot) === displayState.turnIndex}
-                onCardRef={makeCardRefFn(slot.therianId)}
-                onAvatarRef={makeAvatarRefFn(slot.therianId)}
-                mirrored={false}
-                floats={floatNums.get(slot.therianId) ?? []}
+        {/* ── Right column + torch ── */}
+        <div className="absolute pointer-events-none" style={{ right:0, top:0, bottom:0, width:38, zIndex:4, background:'linear-gradient(to left,#100E0C,#1A1612,transparent)' }}>
+          <div style={{ position:'absolute', top:76, right:13, width:15, height:6, background:'#2E2418', borderRadius:3 }} />
+          <div style={{ position:'absolute', top:62, right:19, width:4, height:20, background:'#3A2C18', borderRadius:2 }} />
+          <div style={{ position:'absolute', top:42, right:15, width:11, height:22, background:'radial-gradient(ellipse at 50% 85%,#FF5500,#FF3300 40%,transparent 100%)', borderRadius:'50% 50% 35% 35%', animation:'torchFlicker 2.2s ease-in-out infinite' }} />
+          <div style={{ position:'absolute', top:49, right:17, width:7, height:13, background:'radial-gradient(ellipse at 50% 85%,#FFE000,#FFAA00 55%,transparent 100%)', borderRadius:'50% 50% 35% 35%', animation:'torchFlicker 1.6s ease-in-out infinite reverse' }} />
+          <div style={{ position:'absolute', top:32, right:1, width:36, height:52, background:'radial-gradient(ellipse,rgba(255,110,0,0.32),transparent 70%)', animation:'torchGlow 2.2s ease-in-out infinite' }} />
+        </div>
+
+        {/* ── Arena floor ── */}
+        <div className="absolute bottom-0 inset-x-0 pointer-events-none" style={{ height:90, zIndex:3, background:'linear-gradient(to bottom,#1E1B38,#12102A,#0A0918)', borderTop:'1px solid rgba(140,70,220,0.25)', boxShadow:'inset 0 3px 16px rgba(130,60,210,0.14)' }}>
+          <div style={{ position:'absolute', top:0, left:0, right:0, height:4, background:'rgba(155,89,182,0.32)', boxShadow:'0 0 22px 5px rgba(155,89,182,0.22)' }} />
+          <div style={{ position:'absolute', left:0, right:0, top:'30%', height:1, background:'rgba(155,89,182,0.10)' }} />
+          <div style={{ position:'absolute', left:0, right:0, top:'60%', height:1, background:'rgba(155,89,182,0.07)' }} />
+          <div style={{ position:'absolute', bottom:0, left:0, right:0, height:30, background:'linear-gradient(to top,rgba(90,50,160,0.14),transparent)' }} />
+        </div>
+
+        {/* ── Spotlight characters (1v1: left=attacker, right=defender) ── */}
+        <div className="absolute inset-x-0" style={{ bottom:90, top:110, zIndex:10, display:'flex', alignItems:'flex-end', paddingInline:8 }}>
+
+          {/* Left fighter (attacker side) */}
+          {leftSlot && (
+            <div key={attackerSwitchKey} style={{ flex:1, minWidth:0, display:'flex', justifyContent:'center', animation: attackerSwitchKey > 0 ? 'switchEntryAttacker 0.42s cubic-bezier(0.22,1,0.36,1) both' : 'spotlightEntry 0.4s ease-out both' }}>
+              <SpotlightSlot
+                slot={leftSlot}
+                side="left"
+                onCardRef={makeCardRefFn(leftSlot.therianId)}
+                onAvatarRef={makeAvatarRefFn(leftSlot.therianId)}
+                floats={floatNums.get(leftSlot.therianId) ?? []}
+                onInspect={setInspectedAbilityId}
+                inspectedAbilityId={inspectedAbilityId}
               />
-            ))}
+            </div>
+          )}
+
+          {/* Center: VS + impact burst */}
+          <div style={{ width:48, flexShrink:0, display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', paddingBottom:20, position:'relative' }}>
+            {showBurst && (
+              <div style={{
+                position:'absolute', width:80, height:80, borderRadius:'50%',
+                background: burstType === 'heal'
+                  ? 'radial-gradient(circle,rgba(52,211,153,0.95),rgba(52,211,153,0.4) 40%,transparent 70%)'
+                  : 'radial-gradient(circle,rgba(255,255,255,0.95),rgba(239,68,68,0.6) 35%,transparent 68%)',
+                animation:'impactBurst 0.48s ease-out both',
+                pointerEvents:'none', zIndex:20,
+              }} />
+            )}
+            <span style={{ fontSize:11, fontWeight:900, letterSpacing:2, color:'rgba(255,255,255,0.14)' }}>VS</span>
           </div>
 
-          {/* VS center divider */}
-          <div className="flex flex-col items-center justify-center self-stretch pt-7 gap-1 px-0.5 flex-shrink-0">
-            <div className="w-px flex-1 bg-gradient-to-b from-transparent via-white/8 to-transparent" />
-            <span className="text-white/15 text-[9px] font-black tracking-widest">VS</span>
-            <div className="w-px flex-1 bg-gradient-to-b from-transparent via-white/8 to-transparent" />
-          </div>
-
-          {/* Defender column (avatars mirrored) */}
-          <div className="flex flex-col gap-2 flex-1 min-w-0">
-            <p className="text-[9px] text-white/20 uppercase tracking-widest text-center">Rival</p>
-            {enemySlots.map(slot => (
-              <ArenaSlot
-                key={slot.therianId}
-                slot={slot}
-                isActor={displayState.slots.indexOf(slot) === actorIndex}
-                isNext={displayState.slots.indexOf(slot) === displayState.turnIndex}
-                onCardRef={makeCardRefFn(slot.therianId)}
-                onAvatarRef={makeAvatarRefFn(slot.therianId)}
-                mirrored={true}
-                floats={floatNums.get(slot.therianId) ?? []}
+          {/* Right fighter (defender side) */}
+          {rightSlot ? (
+            <div style={{ flex:1, minWidth:0, display:'flex', justifyContent:'center', animation:'spotlightEntry 0.4s ease-out 0.08s both' }}>
+              <SpotlightSlot
+                slot={rightSlot}
+                side="right"
+                onCardRef={makeCardRefFn(rightSlot.therianId)}
+                onAvatarRef={makeAvatarRefFn(rightSlot.therianId)}
+                floats={floatNums.get(rightSlot.therianId) ?? []}
+                onInspect={setInspectedAbilityId}
+                inspectedAbilityId={inspectedAbilityId}
               />
-            ))}
-          </div>
+            </div>
+          ) : (
+            <div style={{ flex:1, display:'flex', alignItems:'center', justifyContent:'center', opacity:0.18 }}>
+              <span style={{ fontSize:40 }}>?</span>
+            </div>
+          )}
         </div>
       </div>
+      </div>{/* /paddingInline wrapper */}
 
-      {/* ── Turn queue ── */}
+      {/* ── Narrative ── */}
+      {activeAbility && !fetching && (() => {
+        const meta    = archMeta(activeAbility.archetype)
+        const colors  = archColors(activeAbility.archetype)
+        const results = activeAbility.resultLines
+        return (
+          <div style={{
+            borderRadius:14, padding:'12px 16px',
+            background:`linear-gradient(135deg, ${colors.bgLight.replace('0.10','0.18')} 0%, rgba(255,255,255,0.03) 100%)`,
+            border:`1px solid ${colors.ring.replace('0.80','0.28')}`,
+            boxShadow:`0 0 20px ${colors.glow.replace('0.38','0.10')}`,
+          }}>
+            {/* Action line */}
+            <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom: results.length > 0 ? 8 : 0 }}>
+              <span style={{ fontSize:20 }}>{meta.emoji}</span>
+              <div style={{ flex:1, minWidth:0 }}>
+                <span style={{ fontSize:12, color:'rgba(255,255,255,0.55)', fontWeight:500 }}>
+                  {activeAbility.actorName ?? '?'}
+                </span>
+                <span style={{ fontSize:12, color:'rgba(255,255,255,0.30)' }}> usó </span>
+                <span style={{ fontSize:13, fontWeight:800, color:colors.textColor }}>
+                  {activeAbility.abilityName}
+                </span>
+              </div>
+            </div>
+            {/* Result lines */}
+            {results.length > 0 && (
+              <div style={{ display:'flex', flexWrap:'wrap', gap:5 }}>
+                {results.map((line, i) => {
+                  const isHeal   = line.startsWith('+')
+                  const isDead   = line.includes('💀')
+                  const isBlock  = line.includes('Bloqueado') || line.includes('✦')
+                  const isStun   = line.includes('Aturde') || line.includes('Aturdido')
+                  const clr      = isHeal ? '#34D399' : isDead ? '#F87171' : isBlock ? '#FCD34D' : isStun ? '#C084FC' : '#F87171'
+                  return (
+                    <span key={i} style={{
+                      fontSize:14, fontWeight:900, color:clr,
+                      textShadow:`0 0 12px ${clr}70`,
+                      background:'rgba(0,0,0,0.25)', borderRadius:8, padding:'2px 10px',
+                    }}>{line}</span>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )
+      })()}
+
+      {/* ── Manual mode controls ── */}
+      {isManual && displayState.status === 'active' && (() => {
+        const myFrontierId  = displayState.frontliner?.attacker
+        const myFrontliner  = displayState.slots.find(s => s.therianId === myFrontierId)
+        const myBench       = displayState.slots.filter(s => s.side === 'attacker' && !s.isDead && s.therianId !== myFrontierId)
+
+        return (
+          <div style={{
+            background:'rgba(255,255,255,0.02)', border:'1px solid rgba(255,255,255,0.07)',
+            borderRadius:16, padding:'14px 14px', display:'flex', flexDirection:'column', gap:10,
+          }}>
+            {/* Switch panel (forced or voluntary) */}
+            {showSwitchPanel && myBench.length > 0 && (
+              <SwitchPanel
+                benchSlots={myBench}
+                onSwitch={handleManualSwitch}
+                disabled={manualActing}
+                cooldownEnd={switchCooldownEnd}
+                forced={forcedSwitch}
+              />
+            )}
+
+            {/* Ability panel (when waiting for player input and not showing forced switch) */}
+            {manualWaiting && !forcedSwitch && myFrontliner && (
+              <>
+                <ManualAbilityPanel
+                  slot={myFrontliner}
+                  onUse={handleManualAbility}
+                  disabled={manualActing || manualAnimating}
+                  cooldowns={myFrontliner.cooldowns}
+                />
+              </>
+            )}
+
+            {/* AI thinking */}
+            {(manualActing || manualAnimating) && !forcedSwitch && (
+              <div style={{ textAlign:'center', color:'rgba(255,255,255,0.35)', fontSize:12, display:'flex', alignItems:'center', justifyContent:'center', gap:6 }}>
+                <span style={{ width:12, height:12, border:'2px solid rgba(255,255,255,0.15)', borderTopColor:'rgba(255,255,255,0.60)', borderRadius:'50%', animation:'spin 0.8s linear infinite', display:'inline-block' }} />
+                {manualActing ? 'El rival piensa...' : 'Reproduciendo turno...'}
+              </div>
+            )}
+          </div>
+        )
+      })()}
+
+      {/* ── Turn queue (compact) ── */}
       <div className="bg-white/3 border border-white/5 rounded-xl px-3 py-2">
-        <p className="text-white/20 text-[9px] text-center mb-1.5 uppercase tracking-widest">Orden de turno</p>
         <TurnQueueBar
           slots={displayState.slots}
           turnIndex={displayState.turnIndex}
@@ -801,8 +1952,13 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
         />
       </div>
 
-      {/* ── Phase 2: Active ability card ── */}
-      {!fetching && <ActiveAbilityCard info={activeAbility} />}
+      {/* ── Ability inspector ── */}
+      {inspectedAbilityId && (
+        <AbilityInspectorPanel
+          abilityId={inspectedAbilityId}
+          onClose={() => setInspectedAbilityId(null)}
+        />
+      )}
 
       {/* Error */}
       {error && (
@@ -811,11 +1967,10 @@ export default function BattleField({ battleId, initialState, onComplete }: Prop
         </p>
       )}
 
-      {/* Compact combat log */}
+      {/* Combat log (last 2) */}
       {currentLog.length > 0 && (
-        <div className="bg-white/3 border border-white/5 rounded-xl p-3 space-y-1.5">
-          <p className="text-white/20 text-[9px] uppercase tracking-widest mb-1.5">Registro</p>
-          {[...currentLog].reverse().slice(0, 4).map((entry, i) => (
+        <div style={{ background:'rgba(255,255,255,0.02)', border:'1px solid rgba(255,255,255,0.05)', borderRadius:12, padding:'8px 12px', display:'flex', flexDirection:'column', gap:5 }}>
+          {[...currentLog].reverse().slice(0, 2).map((entry, i) => (
             <LogLine key={currentLog.length - 1 - i} entry={entry} isNew={i === 0} />
           ))}
         </div>

--- a/components/pvp/PvpModal.tsx
+++ b/components/pvp/PvpModal.tsx
@@ -1,0 +1,300 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import type { TherianDTO } from '@/lib/therian-dto'
+import PvpRoom from './PvpRoom'
+import type { BattleRewards } from './BattleField'
+
+interface MonthlyReward {
+  gold: number
+  essence: number
+  eggs: string[]
+  accessories: string[]
+  runes: string[]
+}
+
+interface PvpStatus {
+  mmr: number
+  rank: string
+  peakMmr: number
+  peakRank: string
+  weeklyPvpWins: number
+  weeklyRequired: number
+  chestAvailable: boolean
+  alreadyClaimedChest: boolean
+  currentMonth: string
+  monthlyReward: MonthlyReward | null
+  alreadyClaimedMonthly: boolean
+}
+
+interface Props {
+  therians: TherianDTO[]
+  activeBattleId: string | null
+  onClose: () => void
+}
+
+const RANK_ORDER = ['HIERRO', 'BRONCE', 'PLATA', 'ORO', 'PLATINO', 'MITICO']
+const RANK_COLORS: Record<string, string> = {
+  HIERRO:  'text-slate-400',
+  BRONCE:  'text-amber-600',
+  PLATA:   'text-slate-300',
+  ORO:     'text-yellow-400',
+  PLATINO: 'text-cyan-300',
+  MITICO:  'text-purple-400',
+}
+const RANK_BORDERS: Record<string, string> = {
+  HIERRO:  'border-slate-500/40',
+  BRONCE:  'border-amber-600/40',
+  PLATA:   'border-slate-400/40',
+  ORO:     'border-yellow-400/40',
+  PLATINO: 'border-cyan-400/40',
+  MITICO:  'border-purple-500/40',
+}
+const RANK_THRESHOLDS: Record<string, [number, number]> = {
+  HIERRO:  [0, 1000],
+  BRONCE:  [1000, 1400],
+  PLATA:   [1400, 1800],
+  ORO:     [1800, 2200],
+  PLATINO: [2200, 2600],
+  MITICO:  [2600, 3000],
+}
+
+function rankProgress(mmr: number, rank: string): number {
+  const [lo, hi] = RANK_THRESHOLDS[rank] ?? [0, 1000]
+  if (rank === 'MITICO') return 100
+  return Math.min(100, Math.max(0, Math.round(((mmr - lo) / (hi - lo)) * 100)))
+}
+
+export default function PvpModal({ therians, activeBattleId, onClose }: Props) {
+  const [tab, setTab] = useState<'fight' | 'rewards'>('fight')
+  const [status, setStatus] = useState<PvpStatus | null>(null)
+  const [claimingWeekly, setClaimingWeekly] = useState(false)
+  const [claimingMonthly, setClaimingMonthly] = useState(false)
+  const [claimMsg, setClaimMsg] = useState<string | null>(null)
+
+  const fetchStatus = useCallback(() => {
+    fetch('/api/pvp/status')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (data && !data.error) setStatus(data) })
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => { fetchStatus() }, [fetchStatus])
+
+  function handleBattleComplete(_won: boolean, _rewards?: BattleRewards) {
+    fetchStatus()
+  }
+
+  async function claimWeekly() {
+    setClaimingWeekly(true)
+    setClaimMsg(null)
+    try {
+      const res = await fetch('/api/pvp/rewards/weekly', { method: 'POST' })
+      const data = await res.json()
+      if (res.ok) {
+        setClaimMsg(`¡Cofre reclamado! +${data.gold} oro, 1 huevo, 2 runas.`)
+        fetchStatus()
+      } else {
+        setClaimMsg(data.error ?? 'Error al reclamar.')
+      }
+    } finally {
+      setClaimingWeekly(false)
+    }
+  }
+
+  async function claimMonthly() {
+    setClaimingMonthly(true)
+    setClaimMsg(null)
+    try {
+      const res = await fetch('/api/pvp/rewards/monthly', { method: 'POST' })
+      const data = await res.json()
+      if (res.ok) {
+        setClaimMsg(`¡Recompensa mensual reclamada! +${data.gold} oro.`)
+        fetchStatus()
+      } else {
+        setClaimMsg(data.error ?? 'Error al reclamar.')
+      }
+    } finally {
+      setClaimingMonthly(false)
+    }
+  }
+
+  const progress = status ? rankProgress(status.mmr, status.rank) : 0
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+      onClick={e => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="w-full max-w-lg max-h-[90vh] flex flex-col rounded-2xl bg-[#0F0F1A] border border-white/10 overflow-hidden shadow-2xl">
+
+        {/* Header MMR */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-white/8 bg-white/3 shrink-0">
+          <div className="flex items-center gap-3">
+            {status ? (
+              <>
+                <div className={`text-xs font-bold px-2.5 py-1 rounded-lg border ${RANK_COLORS[status.rank]} ${RANK_BORDERS[status.rank]} bg-white/5`}>
+                  {status.rank}
+                </div>
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-white font-semibold text-sm">{status.mmr} MMR</span>
+                    {status.rank !== 'MITICO' && (
+                      <span className="text-white/30 text-xs">
+                        →&nbsp;{RANK_ORDER[RANK_ORDER.indexOf(status.rank) + 1]}
+                      </span>
+                    )}
+                  </div>
+                  <div className="w-40 h-1.5 rounded-full bg-white/10 overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-purple-500 to-cyan-500 transition-all duration-500"
+                      style={{ width: `${progress}%` }}
+                    />
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="w-32 h-6 rounded bg-white/5 animate-pulse" />
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="text-white/30 hover:text-white/70 text-xl transition-colors"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-white/8 shrink-0">
+          <button
+            onClick={() => setTab('fight')}
+            className={`flex-1 py-3 text-sm font-medium transition-colors ${tab === 'fight' ? 'text-white border-b-2 border-purple-500' : 'text-white/40 hover:text-white/60'}`}
+          >
+            ⚔️ Combatir
+          </button>
+          <button
+            onClick={() => setTab('rewards')}
+            className={`flex-1 py-3 text-sm font-medium transition-colors ${tab === 'rewards' ? 'text-white border-b-2 border-purple-500' : 'text-white/40 hover:text-white/60'}`}
+          >
+            🎁 Recompensas
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto">
+          {tab === 'fight' && (
+            <PvpRoom
+              therians={therians}
+              activeBattleId={activeBattleId}
+              onBattleComplete={handleBattleComplete}
+            />
+          )}
+
+          {tab === 'rewards' && (
+            <div className="p-5 space-y-5">
+              {claimMsg && (
+                <div className="text-center text-sm py-2 px-4 rounded-lg bg-purple-500/10 border border-purple-500/20 text-purple-300">
+                  {claimMsg}
+                </div>
+              )}
+
+              {/* Cofre Semanal */}
+              <div className="rounded-xl border border-white/10 bg-white/3 p-4 space-y-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-white font-semibold text-sm">Cofre Semanal</p>
+                  {status?.alreadyClaimedChest && (
+                    <span className="text-xs text-white/30 border border-white/10 rounded px-2 py-0.5">Reclamado</span>
+                  )}
+                </div>
+
+                {status ? (
+                  <>
+                    <div className="space-y-1">
+                      <div className="flex justify-between text-xs text-white/50">
+                        <span>Victorias PvP</span>
+                        <span>{status.weeklyPvpWins} / {status.weeklyRequired}</span>
+                      </div>
+                      <div className="w-full h-2 rounded-full bg-white/10 overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-gradient-to-r from-emerald-500 to-teal-400 transition-all duration-500"
+                          style={{ width: `${Math.min(100, (status.weeklyPvpWins / status.weeklyRequired) * 100)}%` }}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="text-xs text-white/40 space-y-0.5">
+                      <p>🪙 800 oro</p>
+                      <p>🥚 1× Huevo Poco Común</p>
+                      <p>💎 2× Runa T1 aleatoria</p>
+                    </div>
+
+                    <button
+                      onClick={claimWeekly}
+                      disabled={!status.chestAvailable || claimingWeekly}
+                      className="w-full py-2 rounded-lg text-sm font-medium transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-emerald-600 hover:bg-emerald-500 text-white"
+                    >
+                      {claimingWeekly ? 'Reclamando...' : status.alreadyClaimedChest ? 'Ya reclamado esta semana' : status.chestAvailable ? '¡Reclamar cofre!' : `Faltan ${status.weeklyRequired - status.weeklyPvpWins} victorias`}
+                    </button>
+                  </>
+                ) : (
+                  <div className="space-y-2">
+                    <div className="h-3 rounded bg-white/5 animate-pulse" />
+                    <div className="h-8 rounded bg-white/5 animate-pulse" />
+                  </div>
+                )}
+              </div>
+
+              {/* Recompensa Mensual */}
+              <div className="rounded-xl border border-white/10 bg-white/3 p-4 space-y-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-white font-semibold text-sm">Recompensa Mensual</p>
+                  {status?.alreadyClaimedMonthly && (
+                    <span className="text-xs text-white/30 border border-white/10 rounded px-2 py-0.5">Reclamado</span>
+                  )}
+                </div>
+
+                {status ? (
+                  <>
+                    <div className="flex items-center gap-2 text-xs text-white/50">
+                      <span>Pico del mes:</span>
+                      <span className={`font-bold ${RANK_COLORS[status.peakRank]}`}>{status.peakRank}</span>
+                      <span>({status.peakMmr} MMR)</span>
+                    </div>
+
+                    {status.monthlyReward ? (
+                      <div className="text-xs text-white/40 space-y-0.5">
+                        <p>🪙 {status.monthlyReward.gold.toLocaleString()} oro</p>
+                        {status.monthlyReward.essence > 0 && <p>✨ {status.monthlyReward.essence}× Esencia</p>}
+                        {status.monthlyReward.eggs.map((e, i) => <p key={i}>🥚 1× {e}</p>)}
+                        {status.monthlyReward.accessories.map((a, i) => <p key={i}>🎭 1× {a}</p>)}
+                        {status.monthlyReward.runes.map((r, i) => <p key={i}>💎 1× {r}</p>)}
+                      </div>
+                    ) : (
+                      <p className="text-xs text-white/30">Alcanza BRONCE o superior para recibir recompensa mensual.</p>
+                    )}
+
+                    <button
+                      onClick={claimMonthly}
+                      disabled={!status.monthlyReward || status.alreadyClaimedMonthly || claimingMonthly}
+                      className="w-full py-2 rounded-lg text-sm font-medium transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-purple-600 hover:bg-purple-500 text-white"
+                    >
+                      {claimingMonthly ? 'Reclamando...' : status.alreadyClaimedMonthly ? 'Ya reclamado este mes' : !status.monthlyReward ? 'Sin recompensa (HIERRO)' : '¡Reclamar recompensa!'}
+                    </button>
+                  </>
+                ) : (
+                  <div className="space-y-2">
+                    <div className="h-3 rounded bg-white/5 animate-pulse" />
+                    <div className="h-8 rounded bg-white/5 animate-pulse" />
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/components/pvp/PvpPageClient.tsx
+++ b/components/pvp/PvpPageClient.tsx
@@ -1,0 +1,736 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import type { TherianDTO } from '@/lib/therian-dto'
+import PvpRoom from './PvpRoom'
+import TeamSetup from './TeamSetup'
+import TherianAvatar from '@/components/TherianAvatar'
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface MonthlyReward {
+  gold: number
+  essence: number
+  eggs: string[]
+  accessories: string[]
+  runes: string[]
+}
+
+interface PvpStatus {
+  mmr: number
+  rank: string
+  peakMmr: number
+  peakRank: string
+  weeklyPvpWins: number
+  weeklyRequired: number
+  chestAvailable: boolean
+  alreadyClaimedChest: boolean
+  currentMonth: string
+  monthlyReward: MonthlyReward | null
+  alreadyClaimedMonthly: boolean
+  energy: number
+  energyMax: number
+  energyRegenAt: string | null
+}
+
+interface RankingEntry {
+  position: number
+  name: string
+  mmr: number
+  rank: string
+  isCurrentUser: boolean
+}
+
+// ─── Rank constants ───────────────────────────────────────────────────────────
+
+const RANK_ORDER = ['HIERRO', 'BRONCE', 'PLATA', 'ORO', 'PLATINO', 'MITICO']
+
+const RANK_COLORS: Record<string, string> = {
+  HIERRO:  'text-slate-400',
+  BRONCE:  'text-amber-500',
+  PLATA:   'text-slate-300',
+  ORO:     'text-yellow-400',
+  PLATINO: 'text-cyan-300',
+  MITICO:  'text-purple-400',
+}
+
+const RANK_BORDER: Record<string, string> = {
+  HIERRO:  'border-slate-500/30',
+  BRONCE:  'border-amber-600/30',
+  PLATA:   'border-slate-400/30',
+  ORO:     'border-yellow-400/30',
+  PLATINO: 'border-cyan-400/30',
+  MITICO:  'border-purple-500/40',
+}
+
+const RANK_GLOW: Record<string, string> = {
+  HIERRO:  '',
+  BRONCE:  '',
+  PLATA:   '',
+  ORO:     'shadow-[0_0_40px_rgba(250,204,21,0.08)]',
+  PLATINO: 'shadow-[0_0_40px_rgba(34,211,238,0.08)]',
+  MITICO:  'shadow-[0_0_50px_rgba(168,85,247,0.12)]',
+}
+
+const RANK_ICONS: Record<string, string> = {
+  HIERRO:  '🔩',
+  BRONCE:  '🥉',
+  PLATA:   '🥈',
+  ORO:     '🥇',
+  PLATINO: '💠',
+  MITICO:  '🔮',
+}
+
+const RANK_BAR_COLOR: Record<string, string> = {
+  HIERRO:  'from-slate-500 to-slate-400',
+  BRONCE:  'from-amber-600 to-amber-400',
+  PLATA:   'from-slate-400 to-white/60',
+  ORO:     'from-yellow-500 to-yellow-300',
+  PLATINO: 'from-cyan-500 to-cyan-300',
+  MITICO:  'from-purple-500 to-purple-300',
+}
+
+const RANK_THRESHOLDS: Record<string, [number, number]> = {
+  HIERRO:  [0, 1000],
+  BRONCE:  [1000, 1400],
+  PLATA:   [1400, 1800],
+  ORO:     [1800, 2200],
+  PLATINO: [2200, 2600],
+  MITICO:  [2600, 3000],
+}
+
+function rankProgress(mmr: number, rank: string): number {
+  const [lo, hi] = RANK_THRESHOLDS[rank] ?? [0, 1000]
+  if (rank === 'MITICO') return 100
+  return Math.min(100, Math.max(0, Math.round(((mmr - lo) / (hi - lo)) * 100)))
+}
+
+function formatCountdown(targetIso: string): string {
+  const ms = new Date(targetIso).getTime() - Date.now()
+  if (ms <= 0) return 'recargando...'
+  const totalSec = Math.ceil(ms / 1000)
+  const h = Math.floor(totalSec / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m ${s}s`
+  return `${s}s`
+}
+
+// ─── View type ────────────────────────────────────────────────────────────────
+
+type View = 'lobby' | 'fight' | 'team' | 'ranking' | 'info' | 'rewards'
+
+interface Props {
+  therians: TherianDTO[]
+  activeBattleId: string | null
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function PvpPageClient({ therians, activeBattleId }: Props) {
+  const [view, setView] = useState<View>(activeBattleId ? 'fight' : 'lobby')
+  const [status, setStatus] = useState<PvpStatus | null>(null)
+  const [savedTeamIds, setSavedTeamIds] = useState<string[]>([])
+  const [rankingEntries, setRankingEntries] = useState<RankingEntry[] | null>(null)
+  const [rankingCurrentUser, setRankingCurrentUser] = useState<RankingEntry | null>(null)
+  const [claimingWeekly, setClaimingWeekly] = useState(false)
+  const [claimingMonthly, setClaimingMonthly] = useState(false)
+  const [claimMsg, setClaimMsg] = useState<string | null>(null)
+  const [countdown, setCountdown] = useState<string | null>(null)
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const fetchStatus = useCallback(() => {
+    fetch('/api/pvp/status')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (data && !data.error) setStatus(data) })
+      .catch(() => {})
+  }, [])
+
+  const fetchSavedTeam = useCallback(() => {
+    fetch('/api/pvp/team')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (data?.teamIds) setSavedTeamIds(data.teamIds) })
+      .catch(() => {})
+  }, [])
+
+  const fetchRanking = useCallback(() => {
+    fetch('/api/pvp/ranking')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (data?.entries) {
+          setRankingEntries(data.entries)
+          setRankingCurrentUser(data.currentUser ?? null)
+        }
+      })
+      .catch(() => {})
+  }, [])
+
+  useEffect(() => { fetchStatus(); fetchSavedTeam() }, [fetchStatus, fetchSavedTeam])
+
+  // Energy countdown timer
+  useEffect(() => {
+    if (countdownRef.current) clearInterval(countdownRef.current)
+    if (!status?.energyRegenAt) { setCountdown(null); return }
+    setCountdown(formatCountdown(status.energyRegenAt))
+    countdownRef.current = setInterval(() => {
+      if (!status?.energyRegenAt) return
+      const remaining = new Date(status.energyRegenAt).getTime() - Date.now()
+      if (remaining <= 0) {
+        setCountdown(null)
+        fetchStatus()
+        clearInterval(countdownRef.current!)
+      } else {
+        setCountdown(formatCountdown(status.energyRegenAt))
+      }
+    }, 1000)
+    return () => { if (countdownRef.current) clearInterval(countdownRef.current) }
+  }, [status?.energyRegenAt, fetchStatus])
+
+  function handleBattleComplete(_won: boolean) {
+    fetchStatus()
+    // View stays on 'fight' so the result screen is shown; onReturnToLobby handles navigation
+  }
+
+  async function claimWeekly() {
+    setClaimingWeekly(true)
+    setClaimMsg(null)
+    try {
+      const res = await fetch('/api/pvp/rewards/weekly', { method: 'POST' })
+      const data = await res.json()
+      setClaimMsg(res.ok ? `¡Cofre reclamado! +${data.gold} oro, 1 huevo, 2 runas.` : (data.error ?? 'Error al reclamar.'))
+      if (res.ok) fetchStatus()
+    } finally { setClaimingWeekly(false) }
+  }
+
+  async function claimMonthly() {
+    setClaimingMonthly(true)
+    setClaimMsg(null)
+    try {
+      const res = await fetch('/api/pvp/rewards/monthly', { method: 'POST' })
+      const data = await res.json()
+      setClaimMsg(res.ok ? `¡Recompensa mensual reclamada! +${data.gold} oro.` : (data.error ?? 'Error al reclamar.'))
+      if (res.ok) fetchStatus()
+    } finally { setClaimingMonthly(false) }
+  }
+
+  const rank = status?.rank ?? 'HIERRO'
+  const progress = status ? rankProgress(status.mmr, rank) : 0
+  const nextRankLabel = RANK_ORDER[RANK_ORDER.indexOf(rank) + 1]
+  const energy = status?.energy ?? 10
+  const energyMax = status?.energyMax ?? 10
+  const hasRewardBadge = !!(status?.chestAvailable && !status?.alreadyClaimedChest)
+  const hasSavedTeam = savedTeamIds.length === 3
+  const canFight = hasSavedTeam && therians.length >= 3 && energy > 0
+
+  // ─── Sidebar ──────────────────────────────────────────────────────────────
+
+  const sidebar = (
+    <div className="space-y-4">
+
+      {/* Rank card */}
+      {status ? (
+        <div className={`rounded-2xl border p-6 space-y-4 bg-white/3 ${RANK_BORDER[rank]} ${RANK_GLOW[rank]} transition-all duration-500`}>
+          <div className="text-center space-y-1">
+            <div className="text-5xl mb-3">{RANK_ICONS[rank]}</div>
+            <p className={`text-xl font-bold tracking-widest uppercase ${RANK_COLORS[rank]}`}>{rank}</p>
+            <p className="text-white text-4xl font-bold leading-none">{status.mmr}</p>
+            <p className="text-white/25 text-xs uppercase tracking-widest">MMR</p>
+          </div>
+          {rank !== 'MITICO' ? (
+            <div className="space-y-2 pt-1">
+              <div className="flex justify-between text-xs text-white/35">
+                <span>{rank}</span>
+                <span>{nextRankLabel}</span>
+              </div>
+              <div className="h-2 rounded-full bg-white/10 overflow-hidden">
+                <div
+                  className={`h-full rounded-full bg-gradient-to-r ${RANK_BAR_COLOR[rank]} transition-all duration-700`}
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+              <p className="text-center text-xs text-white/20">{progress}% → {nextRankLabel}</p>
+            </div>
+          ) : (
+            <p className="text-center text-xs text-purple-400 font-medium pt-1">⭐ Rango máximo alcanzado</p>
+          )}
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-white/10 p-6 bg-white/3 space-y-3 animate-pulse">
+          <div className="h-12 w-12 rounded-full bg-white/5 mx-auto" />
+          <div className="h-5 rounded bg-white/5 mx-auto w-20" />
+          <div className="h-8 rounded bg-white/5" />
+          <div className="h-2 rounded-full bg-white/5" />
+        </div>
+      )}
+
+      {/* Energy counter */}
+      <div className="rounded-xl border border-white/8 bg-white/3 px-4 py-3 flex items-center justify-between gap-3">
+        <span className="text-white/35 text-xs uppercase tracking-widest">⚡ Energía</span>
+        <div className="flex items-center gap-2">
+          <span className={`font-bold text-lg tabular-nums ${energy === 0 ? 'text-red-400' : energy <= 3 ? 'text-amber-400' : 'text-yellow-300'}`}>
+            {energy}
+          </span>
+          <span className="text-white/25 text-sm">/</span>
+          <span className="text-white/40 text-sm">{energyMax}</span>
+          {energy < energyMax && countdown && (
+            <span className="text-white/25 text-xs border border-white/8 rounded px-1.5 py-0.5 ml-1">
+              +1 en {countdown}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Season stats */}
+      {status && (
+        <div className="rounded-xl border border-white/8 bg-white/3 p-4 space-y-2.5">
+          <p className="text-white/25 text-xs uppercase tracking-widest">Temporada</p>
+          <div className="flex justify-between items-center text-sm">
+            <span className="text-white/45">Pico</span>
+            <span className={`font-semibold ${RANK_COLORS[status.peakRank]}`}>
+              {RANK_ICONS[status.peakRank]} {status.peakRank} · {status.peakMmr}
+            </span>
+          </div>
+          <div className="space-y-1.5">
+            <div className="flex justify-between text-sm">
+              <span className="text-white/45">Victorias sem.</span>
+              <span className="text-white font-medium">{status.weeklyPvpWins} / {status.weeklyRequired}</span>
+            </div>
+            <div className="w-full h-1.5 rounded-full bg-white/10 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-emerald-500/60 transition-all duration-500"
+                style={{ width: `${Math.min(100, (status.weeklyPvpWins / status.weeklyRequired) * 100)}%` }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Battle modes */}
+      <div className="space-y-2">
+        <button
+          onClick={() => hasSavedTeam ? setView('fight') : setView('team')}
+          disabled={hasSavedTeam && !canFight}
+          className={`w-full py-4 rounded-xl font-bold text-lg text-white border shadow-lg transition-all flex items-center justify-center gap-2
+            ${hasSavedTeam
+              ? 'bg-gradient-to-r from-red-600 to-orange-600 hover:from-red-500 hover:to-orange-500 border-red-500/20 shadow-red-900/20 disabled:opacity-40 disabled:cursor-not-allowed'
+              : 'bg-gradient-to-r from-purple-700 to-indigo-700 hover:from-purple-600 hover:to-indigo-600 border-purple-500/20 shadow-purple-900/20'
+            }`}
+        >
+          {hasSavedTeam ? '⚔️ Batalla Clasificatoria' : '🛡️ Configura tu equipo'}
+        </button>
+        {!hasSavedTeam ? (
+          <p className="text-center text-xs text-purple-300/60">
+            Debes guardar un equipo de 3 Therians antes de combatir
+          </p>
+        ) : !canFight && (
+          <p className="text-center text-xs text-white/25">
+            {energy === 0 ? `Sin energía · recarga en ${countdown ?? '...'}` : 'Necesitas al menos 3 Therians'}
+          </p>
+        )}
+        <button
+          disabled
+          className="w-full py-3.5 rounded-xl font-medium text-white/25 border border-white/8 bg-white/2 cursor-not-allowed flex items-center justify-center gap-2"
+        >
+          🤝 Amistosa
+          <span className="text-[10px] font-normal bg-white/8 px-2 py-0.5 rounded-full text-white/20">Próximamente</span>
+        </button>
+      </div>
+
+      {/* Secondary buttons */}
+      <div className="grid grid-cols-3 gap-2">
+        <button
+          onClick={() => setView('team')}
+          className={`py-2.5 rounded-xl border text-xs font-medium transition-colors flex flex-col items-center gap-1 ${view === 'team' ? 'border-purple-500/40 bg-purple-500/10 text-purple-300' : 'border-white/8 bg-white/3 hover:bg-white/5 text-white/50 hover:text-white/80'}`}
+        >
+          <span className="text-base">🛡️</span>
+          Equipo
+        </button>
+        <button
+          onClick={() => { setView('ranking'); fetchRanking() }}
+          className={`py-2.5 rounded-xl border text-xs font-medium transition-colors flex flex-col items-center gap-1 ${view === 'ranking' ? 'border-yellow-500/40 bg-yellow-500/10 text-yellow-300' : 'border-white/8 bg-white/3 hover:bg-white/5 text-white/50 hover:text-white/80'}`}
+        >
+          <span className="text-base">🏆</span>
+          Ranking
+        </button>
+        <button
+          onClick={() => setView('info')}
+          className={`py-2.5 rounded-xl border text-xs font-medium transition-colors flex flex-col items-center gap-1 ${view === 'info' ? 'border-cyan-500/40 bg-cyan-500/10 text-cyan-300' : 'border-white/8 bg-white/3 hover:bg-white/5 text-white/50 hover:text-white/80'}`}
+        >
+          <span className="text-base">ℹ️</span>
+          Liga
+        </button>
+      </div>
+
+      {/* Rewards button */}
+      <button
+        onClick={() => setView('rewards')}
+        className={`w-full py-3 rounded-xl border text-sm font-medium transition-colors flex items-center justify-center gap-2 ${view === 'rewards' ? 'border-emerald-500/30 bg-emerald-500/8 text-emerald-300' : 'border-white/8 bg-white/3 hover:bg-white/5 text-white/50 hover:text-white/80'}`}
+      >
+        🎁 Recompensas
+        {hasRewardBadge && <span className="w-2 h-2 rounded-full bg-emerald-400 animate-pulse" />}
+      </button>
+    </div>
+  )
+
+  // ─── FIGHT VIEW ──────────────────────────────────────────────────────────────
+
+  if (view === 'fight') {
+    return (
+      <div className="space-y-5">
+        <button onClick={() => setView('lobby')} className="text-white/40 hover:text-white/70 text-sm flex items-center gap-1.5 transition-colors">
+          ← Volver al lobby
+        </button>
+        <PvpRoom
+          therians={therians}
+          activeBattleId={activeBattleId}
+          onBattleComplete={handleBattleComplete}
+          onReturnToLobby={() => setView('lobby')}
+          savedTeamIds={savedTeamIds}
+          onTeamSaved={ids => setSavedTeamIds(ids)}
+          initialTeamIds={savedTeamIds.length === 3 ? savedTeamIds : undefined}
+        />
+      </div>
+    )
+  }
+
+  // ─── TEAM VIEW ────────────────────────────────────────────────────────────────
+
+  if (view === 'team') {
+    return (
+      <div className="space-y-5 max-w-2xl mx-auto">
+        <button
+          onClick={() => setView('lobby')}
+          className="text-white/40 hover:text-white/70 text-sm flex items-center gap-1.5 transition-colors"
+        >
+          ← Volver al lobby
+        </button>
+        <TeamSetup
+          therians={therians}
+          onBattleStart={() => {}}
+          savedTeamIds={savedTeamIds}
+          onTeamSaved={ids => setSavedTeamIds(ids)}
+          mode="team-setup"
+        />
+      </div>
+    )
+  }
+
+  // ─── RANKING VIEW ─────────────────────────────────────────────────────────────
+
+  if (view === 'ranking') {
+    return (
+      <div className="grid lg:grid-cols-[300px,1fr] gap-6 items-start">
+        <div>{sidebar}</div>
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-white font-bold text-2xl mb-1">🏆 Ranking</h2>
+            <p className="text-white/35 text-sm">Top jugadores por MMR actual.</p>
+          </div>
+
+          {rankingEntries === null ? (
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="h-14 rounded-xl bg-white/3 animate-pulse" />
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {rankingEntries.map(entry => (
+                <div
+                  key={entry.position}
+                  className={`flex items-center gap-4 rounded-xl border px-5 py-3.5 transition-all ${entry.isCurrentUser ? 'border-purple-500/30 bg-purple-500/8' : 'border-white/8 bg-white/3'}`}
+                >
+                  <span className={`w-7 text-center font-bold text-lg ${entry.position <= 3 ? ['text-yellow-400', 'text-slate-300', 'text-amber-600'][entry.position - 1] : 'text-white/30'}`}>
+                    {entry.position <= 3 ? ['🥇', '🥈', '🥉'][entry.position - 1] : `#${entry.position}`}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className={`font-semibold text-sm truncate ${entry.isCurrentUser ? 'text-purple-200' : 'text-white'}`}>
+                      {entry.name}{entry.isCurrentUser ? ' (tú)' : ''}
+                    </p>
+                  </div>
+                  <span className={`text-xs font-bold px-2.5 py-1 rounded-lg border ${RANK_COLORS[entry.rank]} ${RANK_BORDER[entry.rank]} bg-white/5`}>
+                    {entry.rank}
+                  </span>
+                  <span className="text-white font-bold tabular-nums">{entry.mmr}</span>
+                </div>
+              ))}
+
+              {rankingCurrentUser && (
+                <>
+                  <div className="flex items-center gap-3 my-2">
+                    <div className="flex-1 h-px bg-white/8" />
+                    <span className="text-white/20 text-xs">tu posición</span>
+                    <div className="flex-1 h-px bg-white/8" />
+                  </div>
+                  <div className="flex items-center gap-4 rounded-xl border border-purple-500/30 bg-purple-500/8 px-5 py-3.5">
+                    <span className="w-7 text-center font-bold text-white/40 text-lg">#{rankingCurrentUser.position}</span>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-semibold text-sm text-purple-200 truncate">{rankingCurrentUser.name} (tú)</p>
+                    </div>
+                    <span className={`text-xs font-bold px-2.5 py-1 rounded-lg border ${RANK_COLORS[rankingCurrentUser.rank]} ${RANK_BORDER[rankingCurrentUser.rank]} bg-white/5`}>
+                      {rankingCurrentUser.rank}
+                    </span>
+                    <span className="text-white font-bold tabular-nums">{rankingCurrentUser.mmr}</span>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  // ─── INFO VIEW ────────────────────────────────────────────────────────────────
+
+  if (view === 'info') {
+    const leagues = [
+      { rank: 'HIERRO',  range: '0 – 999',    mmrGold: '50', monthly: 'Sin recompensa' },
+      { rank: 'BRONCE',  range: '1000 – 1399', mmrGold: '50', monthly: '1.500 🪙 · 🥚 Uncommon · 2× Runa T1' },
+      { rank: 'PLATA',   range: '1400 – 1799', mmrGold: '75', monthly: '3.000 🪙 · 🥚 Rare · 3× Runa T1' },
+      { rank: 'ORO',     range: '1800 – 2199', mmrGold: '75', monthly: '6.000 🪙 · 🥚 Epic · 3× Runa T2' },
+      { rank: 'PLATINO', range: '2200 – 2599', mmrGold: '100', monthly: '12.000 🪙 · 🥚 Legendary · 5× Runa T3' },
+      { rank: 'MITICO',  range: '2600+',       mmrGold: '100', monthly: '30.000 🪙 · 🥚 Legendary · 4× Runa T4 · 👑 Corona' },
+    ]
+
+    return (
+      <div className="grid lg:grid-cols-[300px,1fr] gap-6 items-start">
+        <div>{sidebar}</div>
+        <div className="space-y-6">
+          <div>
+            <h2 className="text-white font-bold text-2xl mb-1">ℹ️ Liga PvP</h2>
+            <p className="text-white/35 text-sm">Todo lo que necesitas saber para competir.</p>
+          </div>
+
+          {/* MMR rules */}
+          <div className="rounded-xl border border-white/8 bg-white/3 p-5 space-y-3">
+            <p className="text-white font-semibold text-sm">⚔️ Sistema de MMR</p>
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div className="rounded-lg bg-emerald-900/20 border border-emerald-500/15 p-3 text-center">
+                <p className="text-emerald-400 font-bold text-2xl">+25</p>
+                <p className="text-white/40 text-xs mt-0.5">MMR por victoria</p>
+              </div>
+              <div className="rounded-lg bg-red-900/20 border border-red-500/15 p-3 text-center">
+                <p className="text-red-400 font-bold text-2xl">−15</p>
+                <p className="text-white/40 text-xs mt-0.5">MMR por derrota</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Energy rules */}
+          <div className="rounded-xl border border-white/8 bg-white/3 p-5 space-y-3">
+            <p className="text-white font-semibold text-sm">⚡ Energía de combate</p>
+            <div className="space-y-2 text-sm text-white/50">
+              <div className="flex items-start gap-2"><span>•</span><span>Máximo <strong className="text-white">10 energías</strong>. Cada batalla cuesta 1.</span></div>
+              <div className="flex items-start gap-2"><span>•</span><span>Se regenera <strong className="text-white">1 energía cada 2h 40m</strong> (160 minutos) si no estás al máximo.</span></div>
+              <div className="flex items-start gap-2"><span>•</span><span>Con 10 energías, el temporizador está pausado.</span></div>
+            </div>
+          </div>
+
+          {/* Weekly chest */}
+          <div className="rounded-xl border border-white/8 bg-white/3 p-5 space-y-3">
+            <p className="text-white font-semibold text-sm">🎁 Cofre Semanal</p>
+            <p className="text-white/50 text-sm">Gana <strong className="text-white">15 victorias</strong> en la semana y reclama el cofre:</p>
+            <div className="text-sm text-white/40 space-y-1">
+              <p>🪙 800 oro</p>
+              <p>🥚 1× Huevo Poco Común</p>
+              <p>💎 2× Runa T1 aleatoria</p>
+            </div>
+          </div>
+
+          {/* League table */}
+          <div className="rounded-xl border border-white/8 bg-white/3 overflow-hidden">
+            <div className="px-5 py-3 border-b border-white/8">
+              <p className="text-white font-semibold text-sm">🏅 Rangos y recompensas mensuales</p>
+              <p className="text-white/30 text-xs mt-0.5">Las recompensas se basan en el pico de rango del mes.</p>
+            </div>
+            <div className="divide-y divide-white/5">
+              {leagues.map(l => (
+                <div key={l.rank} className="flex items-start gap-3 px-5 py-3.5">
+                  <span className="text-xl leading-none mt-0.5">{RANK_ICONS[l.rank]}</span>
+                  <div className="flex-1 min-w-0 space-y-0.5">
+                    <div className="flex items-center gap-2">
+                      <span className={`font-bold text-sm ${RANK_COLORS[l.rank]}`}>{l.rank}</span>
+                      <span className="text-white/25 text-xs">{l.range} MMR</span>
+                      <span className="text-yellow-400/70 text-xs ml-auto">+{l.mmrGold}🪙 /win</span>
+                    </div>
+                    <p className="text-white/35 text-xs">{l.monthly}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // ─── REWARDS VIEW ─────────────────────────────────────────────────────────────
+
+  if (view === 'rewards') {
+    return (
+      <div className="grid lg:grid-cols-[300px,1fr] gap-6 items-start">
+        <div>{sidebar}</div>
+        <div className="space-y-6 max-w-lg">
+          <h2 className="text-white font-bold text-2xl">🎁 Recompensas PvP</h2>
+
+          {claimMsg && (
+            <div className="text-center text-sm py-2 px-4 rounded-lg bg-purple-500/10 border border-purple-500/20 text-purple-300">
+              {claimMsg}
+            </div>
+          )}
+
+          {/* Cofre Semanal */}
+          <div className="rounded-xl border border-white/10 bg-white/3 p-5 space-y-4">
+            <div className="flex items-center justify-between">
+              <p className="text-white font-semibold">Cofre Semanal</p>
+              {status?.alreadyClaimedChest && (
+                <span className="text-xs text-white/30 border border-white/10 rounded px-2 py-0.5">Reclamado</span>
+              )}
+            </div>
+            {status ? (
+              <>
+                <div className="space-y-1.5">
+                  <div className="flex justify-between text-sm text-white/50">
+                    <span>Victorias PvP</span>
+                    <span>{status.weeklyPvpWins} / {status.weeklyRequired}</span>
+                  </div>
+                  <div className="w-full h-2 rounded-full bg-white/10 overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-emerald-500 to-teal-400 transition-all duration-500"
+                      style={{ width: `${Math.min(100, (status.weeklyPvpWins / status.weeklyRequired) * 100)}%` }}
+                    />
+                  </div>
+                </div>
+                <div className="text-sm text-white/40 space-y-1">
+                  <p>🪙 800 oro · 🥚 1× Huevo Poco Común · 💎 2× Runa T1 aleatoria</p>
+                </div>
+                <button
+                  onClick={claimWeekly}
+                  disabled={!status.chestAvailable || claimingWeekly}
+                  className="w-full py-2.5 rounded-lg text-sm font-medium transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-emerald-600 hover:bg-emerald-500 text-white"
+                >
+                  {claimingWeekly ? 'Reclamando...' : status.alreadyClaimedChest ? 'Ya reclamado esta semana' : status.chestAvailable ? '¡Reclamar cofre!' : `Faltan ${status.weeklyRequired - status.weeklyPvpWins} victorias`}
+                </button>
+              </>
+            ) : <div className="h-16 rounded bg-white/5 animate-pulse" />}
+          </div>
+
+          {/* Recompensa Mensual */}
+          <div className="rounded-xl border border-white/10 bg-white/3 p-5 space-y-4">
+            <div className="flex items-center justify-between">
+              <p className="text-white font-semibold">Recompensa Mensual</p>
+              {status?.alreadyClaimedMonthly && (
+                <span className="text-xs text-white/30 border border-white/10 rounded px-2 py-0.5">Reclamado</span>
+              )}
+            </div>
+            {status ? (
+              <>
+                <div className="flex items-center gap-2 text-sm text-white/50">
+                  <span>Pico del mes:</span>
+                  <span className={`font-bold ${RANK_COLORS[status.peakRank]}`}>{status.peakRank}</span>
+                  <span>({status.peakMmr} MMR)</span>
+                </div>
+                {status.monthlyReward ? (
+                  <div className="text-sm text-white/40 space-y-1">
+                    <p>🪙 {status.monthlyReward.gold.toLocaleString()} oro</p>
+                    {status.monthlyReward.essence > 0 && <p>✨ {status.monthlyReward.essence}× Esencia</p>}
+                    {status.monthlyReward.eggs.map((e, i) => <p key={i}>🥚 1× {e}</p>)}
+                    {status.monthlyReward.accessories.map((a, i) => <p key={i}>🎭 1× {a}</p>)}
+                    {status.monthlyReward.runes.map((r, i) => <p key={i}>💎 1× {r}</p>)}
+                  </div>
+                ) : (
+                  <p className="text-sm text-white/30">Alcanza BRONCE o superior para recibir recompensa mensual.</p>
+                )}
+                <button
+                  onClick={claimMonthly}
+                  disabled={!status.monthlyReward || status.alreadyClaimedMonthly || claimingMonthly}
+                  className="w-full py-2.5 rounded-lg text-sm font-medium transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-purple-600 hover:bg-purple-500 text-white"
+                >
+                  {claimingMonthly ? 'Reclamando...' : status.alreadyClaimedMonthly ? 'Ya reclamado este mes' : !status.monthlyReward ? 'Sin recompensa (HIERRO)' : '¡Reclamar recompensa!'}
+                </button>
+              </>
+            ) : <div className="h-16 rounded bg-white/5 animate-pulse" />}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // ─── LOBBY VIEW ───────────────────────────────────────────────────────────────
+
+  return (
+    <div className="grid lg:grid-cols-[300px,1fr] gap-6 items-start">
+      <div>{sidebar}</div>
+
+      {/* Arena visual */}
+      <div className="space-y-4">
+        <div className="relative rounded-2xl overflow-hidden border border-white/8 min-h-[400px] flex flex-col bg-[#08080F]">
+          <div className="absolute inset-0 pointer-events-none">
+            <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[500px] h-[250px] rounded-full blur-[120px] opacity-20 bg-red-800" />
+            <div className="absolute bottom-0 left-0 right-0 h-1/3 bg-gradient-to-t from-[#08080F] to-transparent" />
+            <div className="absolute bottom-16 left-1/2 -translate-x-1/2 w-[300px] h-[40px] rounded-full blur-[30px] opacity-25 bg-red-700" />
+          </div>
+
+          <div className="relative flex items-center justify-between px-6 pt-5 pb-2">
+            <div className="flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse" />
+              <span className="text-white/30 text-xs uppercase tracking-widest font-medium">Arena PvP</span>
+            </div>
+            <span className="text-white/15 text-xs">Temporada activa</span>
+          </div>
+
+          <div className="flex-1 flex items-end justify-center pb-10 relative">
+            {(() => {
+              const arenaTherians = savedTeamIds.length === 3
+                ? savedTeamIds.map(id => therians.find(t => t.id === id)).filter(Boolean) as typeof therians
+                : therians.slice(0, 3)
+              return arenaTherians.length > 0 ? (
+                <div className="flex items-end justify-center gap-8">
+                  {arenaTherians.map((t, i) => {
+                    const isCenter = arenaTherians.length === 1 || i === 1
+                    return (
+                      <div
+                        key={t.id}
+                        className="flex flex-col items-center gap-2 transition-all duration-300"
+                        style={{ transform: isCenter ? 'translateY(-24px) scale(1.18)' : 'scale(1)', zIndex: isCenter ? 10 : 5 }}
+                      >
+                        <div style={isCenter ? { filter: 'drop-shadow(0 0 18px rgba(239,68,68,0.35))' } : {}}>
+                          <TherianAvatar therian={t} size={isCenter ? 100 : 76} />
+                        </div>
+                        <p className="text-white/35 text-xs text-center max-w-[88px] truncate">{t.name ?? t.species.name}</p>
+                      </div>
+                    )
+                  })}
+                </div>
+              ) : <p className="text-white/15 text-sm">Sin Therians</p>
+            })()}
+            <div className="absolute bottom-4 left-8 right-8 h-px bg-gradient-to-r from-transparent via-red-800/40 to-transparent" />
+          </div>
+
+          <div className="relative px-6 py-4 text-center">
+            <p className="text-white/35 text-sm">
+              {!hasSavedTeam
+                ? 'Ve a Equipo y guarda tu formación de 3 Therians'
+                : energy === 0
+                  ? `Sin energía · recarga en ${countdown ?? '...'}`
+                  : 'Equipo guardado listo para combatir'}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-xl border border-white/8 bg-white/3 p-4 text-center">
+            <p className="text-white/25 text-xs uppercase tracking-widest mb-1.5">Therians</p>
+            <p className="text-white text-3xl font-bold">{therians.length}</p>
+          </div>
+          <div className="rounded-xl border border-white/8 bg-white/3 p-4 text-center">
+            <p className="text-white/25 text-xs uppercase tracking-widest mb-1.5">Victorias sem.</p>
+            <p className="text-white text-3xl font-bold">{status?.weeklyPvpWins ?? '—'}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/pvp/PvpRoom.tsx
+++ b/components/pvp/PvpRoom.tsx
@@ -1,23 +1,45 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import Image from 'next/image'
 import type { TherianDTO } from '@/lib/therian-dto'
 import type { BattleState } from '@/lib/pvp/types'
 import TeamSetup from './TeamSetup'
 import BattleField from './BattleField'
+import type { BattleRewards } from './BattleField'
+import { getRankFromMmr } from '@/lib/pvp/mmr'
+
+const RANK_META = {
+  HIERRO:  { label: 'Hierro',  color: 'text-gray-300',   border: 'border-gray-500/40',  bg: 'bg-gray-500/10',   glow: 'shadow-gray-500/20'   },
+  BRONCE:  { label: 'Bronce',  color: 'text-orange-300', border: 'border-orange-500/40', bg: 'bg-orange-500/10', glow: 'shadow-orange-500/20' },
+  PLATA:   { label: 'Plata',   color: 'text-slate-200',  border: 'border-slate-400/40',  bg: 'bg-slate-400/10',  glow: 'shadow-slate-400/20'  },
+  ORO:     { label: 'Oro',     color: 'text-yellow-300', border: 'border-yellow-500/40', bg: 'bg-yellow-500/10', glow: 'shadow-yellow-500/25' },
+  PLATINO: { label: 'Platino', color: 'text-cyan-300',   border: 'border-cyan-400/40',   bg: 'bg-cyan-400/10',   glow: 'shadow-cyan-400/25'   },
+  MITICO:  { label: 'Mítico',  color: 'text-purple-300', border: 'border-purple-500/40', bg: 'bg-purple-500/10', glow: 'shadow-purple-500/30' },
+} as const
 
 interface Props {
   therians: TherianDTO[]
   activeBattleId: string | null
+  onBattleComplete?: (won: boolean, rewards?: BattleRewards) => void
+  onReturnToLobby?: () => void
+  savedTeamIds?: string[]
+  onTeamSaved?: (ids: string[]) => void
+  /** Si se proporcionan 3 IDs, la batalla empieza automáticamente sin mostrar la pantalla de selección */
+  initialTeamIds?: string[]
 }
 
-type Phase = 'setup' | 'loading_battle' | 'battle' | 'result'
+type Phase = 'setup' | 'starting' | 'loading_battle' | 'battle' | 'result'
 
-export default function PvpRoom({ therians, activeBattleId }: Props) {
-  const [phase, setPhase] = useState<Phase>(activeBattleId ? 'loading_battle' : 'setup')
+export default function PvpRoom({ therians, activeBattleId, onBattleComplete, onReturnToLobby, savedTeamIds, onTeamSaved, initialTeamIds }: Props) {
+  const startPhase: Phase = activeBattleId ? 'loading_battle' : initialTeamIds?.length === 3 ? 'starting' : 'setup'
+  const [phase, setPhase] = useState<Phase>(startPhase)
   const [battleId, setBattleId] = useState<string | null>(activeBattleId)
   const [battleState, setBattleState] = useState<BattleState | null>(null)
   const [won, setWon] = useState<boolean | null>(null)
+  const [rewards, setRewards] = useState<BattleRewards | undefined>(undefined)
+  const [startError, setStartError] = useState<string | null>(null)
+  const startingRef = useRef(false)
 
   // Si hay batalla activa en props → cargarla
   useEffect(() => {
@@ -36,35 +58,86 @@ export default function PvpRoom({ therians, activeBattleId }: Props) {
       .catch(() => setPhase('setup'))
   }, [activeBattleId])
 
+  // Auto-start con equipo guardado
+  useEffect(() => {
+    if (phase !== 'starting' || !initialTeamIds || initialTeamIds.length !== 3) return
+    if (startingRef.current) return
+    startingRef.current = true
+
+    fetch('/api/pvp/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ attackerTeamIds: initialTeamIds }),
+    })
+      .then(r => r.json())
+      .then(data => {
+        if (data.battleId && data.state) {
+          setBattleId(data.battleId)
+          setBattleState(data.state)
+          setPhase('battle')
+        } else if (data.error === 'BATTLE_IN_PROGRESS') {
+          setStartError('Ya tienes una batalla en curso.')
+          setPhase('setup')
+        } else if (data.error === 'NO_ENERGY') {
+          setStartError('Sin energía. Espera a que se recargue.')
+          setPhase('setup')
+        } else if (data.error === 'NO_OPPONENTS') {
+          setStartError('No se encontraron rivales. Intenta más tarde.')
+          setPhase('setup')
+        } else {
+          setStartError(data.error ?? 'Error al iniciar la batalla.')
+          setPhase('setup')
+        }
+      })
+      .catch(() => {
+        setStartError('Error de conexión.')
+        setPhase('setup')
+      })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase])
+
   function handleBattleStart(id: string, state: BattleState) {
     setBattleId(id)
     setBattleState(state)
     setPhase('battle')
   }
 
-  function handleComplete(playerWon: boolean) {
+  function handleComplete(playerWon: boolean, battleRewards?: BattleRewards) {
     setWon(playerWon)
+    setRewards(battleRewards)
     setPhase('result')
+    onBattleComplete?.(playerWon, battleRewards)
   }
 
   function handleNewBattle() {
     setBattleId(null)
     setBattleState(null)
     setWon(null)
+    setRewards(undefined)
     setPhase('setup')
   }
 
-  if (phase === 'loading_battle') {
+  if (phase === 'loading_battle' || phase === 'starting') {
     return (
       <div className="flex flex-col items-center justify-center py-20 gap-4">
         <div className="w-8 h-8 border-2 border-white/20 border-t-white/80 rounded-full animate-spin" />
-        <p className="text-white/40 text-sm">Cargando batalla...</p>
+        <p className="text-white/40 text-sm">
+          {phase === 'starting' ? 'Buscando rival...' : 'Cargando batalla...'}
+        </p>
       </div>
     )
   }
 
   if (phase === 'setup') {
-    return <TeamSetup therians={therians} onBattleStart={handleBattleStart} />
+    return (
+      <TeamSetup
+        therians={therians}
+        onBattleStart={handleBattleStart}
+        savedTeamIds={savedTeamIds}
+        onTeamSaved={onTeamSaved}
+        externalError={startError ?? undefined}
+      />
+    )
   }
 
   if (phase === 'battle' && battleId && battleState) {
@@ -78,20 +151,100 @@ export default function PvpRoom({ therians, activeBattleId }: Props) {
   }
 
   if (phase === 'result') {
+    const isWin = won === true
     return (
-      <div className="text-center space-y-6 py-16">
-        <p className="text-7xl">{won ? '🏆' : '💀'}</p>
-        <div className="space-y-1">
-          <p className="text-2xl font-bold text-white">{won ? '¡Victoria!' : 'Derrota'}</p>
-          <p className="text-white/40 text-sm">
-            {won ? 'Derrotaste al rival.' : 'Tu equipo fue eliminado.'}
-          </p>
+      <div className="relative flex flex-col items-center py-10 overflow-hidden">
+        {/* Background glow */}
+        <div className="absolute inset-0 pointer-events-none">
+          <div
+            className={`absolute top-0 left-1/2 -translate-x-1/2 w-[500px] h-[300px] rounded-full blur-[120px] opacity-20 ${isWin ? 'bg-yellow-500' : 'bg-red-800'}`}
+          />
         </div>
-        <button
-          onClick={handleNewBattle}
-          className="px-6 py-3 rounded-xl bg-white/10 hover:bg-white/15 border border-white/10 text-white font-medium transition-all"
+
+        {/* Trophy / Skull */}
+        <div
+          className="relative text-[96px] leading-none mb-2 animate-bounce"
+          style={{ animationDuration: '2s', animationIterationCount: isWin ? '3' : '1' }}
         >
-          ⚔️ Nueva batalla
+          {isWin ? '🏆' : '💀'}
+        </div>
+
+        {/* Result title */}
+        <h2
+          className={`text-4xl font-extrabold tracking-tight mb-1 ${isWin ? 'text-yellow-400' : 'text-red-400'}`}
+        >
+          {isWin ? '¡Victoria!' : 'Derrota'}
+        </h2>
+        <p className="text-white/30 text-sm mb-8">
+          {isWin ? 'Derrotaste al rival.' : 'Tu equipo fue eliminado.'}
+        </p>
+
+        {/* Rank-up banner */}
+        {isWin && rewards && (() => {
+          const prevRank = getRankFromMmr(rewards.newMmr - rewards.mmrDelta)
+          if (prevRank === rewards.rank) return null
+          const meta = RANK_META[rewards.rank as keyof typeof RANK_META]
+          const prevMeta = RANK_META[prevRank as keyof typeof RANK_META]
+          if (!meta) return null
+          return (
+            <div className={`w-full max-w-sm rounded-2xl border p-5 text-center space-y-3 mb-2 ${meta.border} ${meta.bg} shadow-xl ${meta.glow}`}>
+              <p className={`text-[11px] uppercase tracking-widest font-bold ${meta.color} opacity-70`}>
+                ¡Ascenso de rango!
+              </p>
+              <Image
+                src={`/ranks/${rewards.rank.toLowerCase()}.svg`}
+                alt={meta.label}
+                width={88}
+                height={106}
+                className="mx-auto drop-shadow-2xl"
+                style={{ filter: 'drop-shadow(0 0 12px currentColor)' }}
+              />
+              <p className={`text-2xl font-extrabold tracking-wide ${meta.color}`}>
+                {meta.label}
+              </p>
+              <p className="text-white/35 text-xs">
+                {prevMeta?.label ?? prevRank} → {meta.label}
+              </p>
+            </div>
+          )
+        })()}
+
+        {/* Rewards card */}
+        {rewards && (
+          <div className={`w-full max-w-sm rounded-2xl border p-6 space-y-4 mb-8 ${isWin ? 'border-yellow-500/20 bg-yellow-900/10' : 'border-red-500/15 bg-red-900/8'}`}>
+            {/* MMR delta — big and prominent */}
+            <div className="text-center space-y-0.5">
+              <p className="text-white/30 text-xs uppercase tracking-widest">MMR</p>
+              <p className={`text-5xl font-extrabold ${rewards.mmrDelta >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                {rewards.mmrDelta >= 0 ? '+' : ''}{rewards.mmrDelta}
+              </p>
+              <p className="text-white/50 text-sm">→ {rewards.newMmr} MMR · {rewards.rank}</p>
+            </div>
+
+            <div className="h-px bg-white/8" />
+
+            {/* Gold */}
+            {rewards.goldEarned > 0 && (
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-white/50">Oro ganado</span>
+                <span className="text-yellow-400 font-bold text-lg">+{rewards.goldEarned} 🪙</span>
+              </div>
+            )}
+
+            {/* Weekly wins */}
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-white/50">Victorias semanales</span>
+              <span className="text-white font-medium">{rewards.weeklyPvpWins} / 15</span>
+            </div>
+          </div>
+        )}
+
+        {/* Next button */}
+        <button
+          onClick={onReturnToLobby ?? handleNewBattle}
+          className={`px-10 py-3.5 rounded-xl font-bold text-lg text-white transition-all ${isWin ? 'bg-gradient-to-r from-yellow-600 to-amber-600 hover:from-yellow-500 hover:to-amber-500 shadow-lg shadow-yellow-900/30' : 'bg-white/10 hover:bg-white/15 border border-white/10'}`}
+        >
+          {onReturnToLobby ? '← Volver al lobby' : 'Siguiente →'}
         </button>
       </div>
     )

--- a/components/pvp/PvpRoom.tsx
+++ b/components/pvp/PvpRoom.tsx
@@ -67,7 +67,7 @@ export default function PvpRoom({ therians, activeBattleId, onBattleComplete, on
     fetch('/api/pvp/start', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ attackerTeamIds: initialTeamIds }),
+      body: JSON.stringify({ attackerTeamIds: initialTeamIds, mode: 'manual' }),
     })
       .then(r => r.json())
       .then(data => {

--- a/components/pvp/TeamSetup.tsx
+++ b/components/pvp/TeamSetup.tsx
@@ -3,35 +3,47 @@
 import { useState } from 'react'
 import type { TherianDTO } from '@/lib/therian-dto'
 import type { BattleState } from '@/lib/pvp/types'
-import { ABILITY_BY_ID } from '@/lib/pvp/abilities'
-import { INNATE_BY_ARCHETYPE } from '@/lib/pvp/abilities'
+import { ABILITY_BY_ID, INNATE_BY_ARCHETYPE } from '@/lib/pvp/abilities'
 import TherianAvatar from '@/components/TherianAvatar'
 
 interface Props {
   therians: TherianDTO[]
   onBattleStart: (battleId: string, state: BattleState) => void
+  savedTeamIds?: string[]
+  onTeamSaved?: (ids: string[]) => void
+  mode?: 'battle' | 'team-setup'
+  externalError?: string
 }
 
 const ARCH_META = {
-  forestal:  { emoji: '🌿', border: 'border-emerald-500/60', text: 'text-emerald-400', bg: 'bg-emerald-500/10', pill: 'bg-emerald-500/20 text-emerald-300' },
-  electrico: { emoji: '⚡', border: 'border-yellow-500/60',  text: 'text-yellow-400',  bg: 'bg-yellow-500/10',  pill: 'bg-yellow-500/20 text-yellow-300' },
-  acuatico:  { emoji: '💧', border: 'border-blue-500/60',    text: 'text-blue-400',    bg: 'bg-blue-500/10',    pill: 'bg-blue-500/20 text-blue-300' },
-  volcanico: { emoji: '🔥', border: 'border-orange-500/60',  text: 'text-orange-400',  bg: 'bg-orange-500/10',  pill: 'bg-orange-500/20 text-orange-300' },
+  forestal:  { emoji: '🌿', border: 'border-emerald-500/50', text: 'text-emerald-400', bg: 'bg-emerald-500/8', pill: 'bg-emerald-500/15 text-emerald-300 border border-emerald-500/20' },
+  electrico: { emoji: '⚡', border: 'border-yellow-500/50',  text: 'text-yellow-400',  bg: 'bg-yellow-500/8',  pill: 'bg-yellow-500/15 text-yellow-300 border border-yellow-500/20' },
+  acuatico:  { emoji: '💧', border: 'border-blue-500/50',    text: 'text-blue-400',    bg: 'bg-blue-500/8',    pill: 'bg-blue-500/15 text-blue-300 border border-blue-500/20' },
+  volcanico: { emoji: '🔥', border: 'border-orange-500/50',  text: 'text-orange-400',  bg: 'bg-orange-500/8',  pill: 'bg-orange-500/15 text-orange-300 border border-orange-500/20' },
 } as const
 
 const RARITY_BORDER: Record<string, string> = {
   COMMON:    'border-white/10',
-  UNCOMMON:  'border-emerald-500/30',
+  UNCOMMON:  'border-emerald-500/25',
   RARE:      'border-blue-500/30',
   EPIC:      'border-purple-500/40',
   LEGENDARY: 'border-amber-500/50',
-  MYTHIC:    'border-red-500/60',
+  MYTHIC:    'border-red-500/55',
+}
+
+const RARITY_COLORS: Record<string, string> = {
+  COMMON:    'text-white/40',
+  UNCOMMON:  'text-emerald-400/80',
+  RARE:      'text-blue-400/80',
+  EPIC:      'text-purple-400/80',
+  LEGENDARY: 'text-amber-400/80',
+  MYTHIC:    'text-red-400/80',
 }
 
 const TIER_COLORS: Record<string, { border: string; badge: string; glow: string }> = {
-  standard:     { border: 'border-slate-500/40',  badge: 'bg-slate-500/20 text-slate-300',    glow: '' },
-  premium:      { border: 'border-purple-500/50', badge: 'bg-purple-500/20 text-purple-300',  glow: 'shadow-[0_0_12px_rgba(168,85,247,0.15)]' },
-  premium_plus: { border: 'border-amber-500/50',  badge: 'bg-amber-500/20 text-amber-300',    glow: 'shadow-[0_0_16px_rgba(245,158,11,0.2)]' },
+  standard:     { border: 'border-slate-500/30',  badge: 'bg-slate-500/15 text-slate-300 border border-slate-500/20',    glow: '' },
+  premium:      { border: 'border-purple-500/40', badge: 'bg-purple-500/15 text-purple-300 border border-purple-500/20', glow: 'shadow-[0_0_16px_rgba(168,85,247,0.12)]' },
+  premium_plus: { border: 'border-amber-500/40',  badge: 'bg-amber-500/15 text-amber-300 border border-amber-500/20',    glow: 'shadow-[0_0_20px_rgba(245,158,11,0.15)]' },
 }
 
 const TIER_LABEL: Record<string, string> = {
@@ -40,12 +52,15 @@ const TIER_LABEL: Record<string, string> = {
   premium_plus: 'Legendario',
 }
 
-export default function TeamSetup({ therians, onBattleStart }: Props) {
-  const [selected, setSelected] = useState<Set<string>>(new Set())
+export default function TeamSetup({ therians, onBattleStart, savedTeamIds, onTeamSaved, mode = 'battle', externalError }: Props) {
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set((savedTeamIds ?? []).filter(id => therians.some(t => t.id === id)))
+  )
   const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [saveMsg, setSaveMsg] = useState<string | null>(null)
 
-  // Líder del equipo seleccionado = mayor CHA → determina el aura activa
   const selectedTherians = therians.filter(t => selected.has(t.id))
   const leader = selectedTherians.length > 0
     ? selectedTherians.reduce((best, t) => t.stats.charisma > best.stats.charisma ? t : best)
@@ -64,6 +79,31 @@ export default function TeamSetup({ therians, onBattleStart }: Props) {
     })
   }
 
+  async function handleSaveTeam() {
+    if (selected.size !== 3) return
+    setSaving(true)
+    setSaveMsg(null)
+    setError(null)
+    try {
+      const res = await fetch('/api/pvp/team', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ teamIds: Array.from(selected) }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (res.ok) {
+        setSaveMsg('✓ Equipo guardado correctamente')
+        onTeamSaved?.(Array.from(selected))
+      } else {
+        setSaveMsg(`Error: ${data.error ?? 'No se pudo guardar el equipo'}`)
+      }
+    } catch {
+      setSaveMsg('Error de conexión.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
   async function handleStart() {
     if (selected.size !== 3) return
     setLoading(true)
@@ -75,13 +115,15 @@ export default function TeamSetup({ therians, onBattleStart }: Props) {
         body: JSON.stringify({ attackerTeamIds: Array.from(selected) }),
       })
       let data: Record<string, unknown> = {}
-      try { data = await res.json() } catch { /* response no-JSON */ }
+      try { data = await res.json() } catch { /* no-JSON */ }
 
       if (!res.ok) {
         if (data.error === 'BATTLE_IN_PROGRESS') {
           setError('Ya tienes una batalla en curso.')
         } else if (data.error === 'NO_OPPONENTS') {
           setError('No se encontraron rivales. Intenta más tarde.')
+        } else if (data.error === 'NO_ENERGY') {
+          setError('Sin energía. Espera a que se recargue.')
         } else if (data.error === 'ENGINE_ERROR') {
           setError(`Error interno del motor: ${data.detail ?? ''}`)
         } else {
@@ -98,65 +140,69 @@ export default function TeamSetup({ therians, onBattleStart }: Props) {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       {/* Header */}
       <div className="text-center space-y-1">
-        <h1 className="text-2xl font-bold text-white">⚔️ Arena PvP</h1>
-        <p className="text-white/40 text-sm">Selecciona 3 Therians para combatir</p>
+        <h1 className="text-2xl font-bold text-white tracking-tight">
+          {mode === 'team-setup' ? '🛡️ Configurar Equipo' : '⚔️ Arena PvP'}
+        </h1>
+        <p className="text-white/35 text-sm">
+          {mode === 'team-setup'
+            ? 'Selecciona 3 Therians y guarda tu formación'
+            : 'Selecciona 3 Therians para combatir'}
+        </p>
       </div>
 
-      {/* Counter */}
-      <div className="flex items-center justify-center gap-3">
+      {/* Selection tracker */}
+      <div className="flex items-center justify-center gap-2">
         {[0, 1, 2].map(i => (
           <div
             key={i}
-            className={`w-8 h-8 rounded-full border-2 flex items-center justify-center text-xs font-bold transition-all ${
+            className={`w-9 h-9 rounded-full border-2 flex items-center justify-center text-xs font-bold transition-all duration-200 ${
               selected.size > i
-                ? 'border-white/60 bg-white/10 text-white'
-                : 'border-white/20 text-white/20'
+                ? 'border-aurora-500/70 bg-aurora-500/15 text-white shadow-[0_0_12px_rgba(155,89,182,0.2)]'
+                : 'border-white/15 text-white/25'
             }`}
           >
             {selected.size > i ? '✓' : i + 1}
           </div>
         ))}
-        <span className="text-white/40 text-sm ml-1">{selected.size}/3 seleccionados</span>
+        <span className="text-white/35 text-sm ml-2 tabular-nums">{selected.size}/3</span>
       </div>
 
-      {/* Aura activa de la formación */}
-      <div className={`rounded-xl border p-3 transition-all duration-300 min-h-[60px] ${
-        activeAura
-          ? `${TIER_COLORS[activeAura.tier]?.border ?? 'border-white/10'} bg-white/3 ${TIER_COLORS[activeAura.tier]?.glow ?? ''}`
-          : 'border-white/8 bg-white/2'
-      }`}>
-        {activeAura ? (
-          <div className="flex items-start gap-2">
+      {/* Aura activa */}
+      {activeAura ? (
+        <div className={`rounded-xl border p-3.5 transition-all duration-300 ${
+          TIER_COLORS[activeAura.tier]?.border ?? 'border-white/10'
+        } bg-white/3 ${TIER_COLORS[activeAura.tier]?.glow ?? ''}`}>
+          <div className="flex items-start gap-2.5">
             <span className="text-lg leading-none mt-0.5">
-              {ARCH_META[activeAura.archetype as keyof typeof ARCH_META]?.emoji ?? '✨'}
+              {activeAura.archetype === 'forestal' ? '🌿' : activeAura.archetype === 'electrico' ? '⚡' : activeAura.archetype === 'acuatico' ? '💧' : '🔥'}
             </span>
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 flex-wrap mb-0.5">
-                <span className="text-white/40 text-[10px] uppercase tracking-widest">Aura activa</span>
+                <span className="text-white/35 text-[10px] uppercase tracking-widest">Aura del líder</span>
                 <span className={`text-[9px] px-2 py-0.5 rounded-full font-medium uppercase tracking-wide ${TIER_COLORS[activeAura.tier]?.badge ?? ''}`}>
                   {TIER_LABEL[activeAura.tier] ?? activeAura.tier}
                 </span>
-                <span className="text-white/25 text-[10px]">
-                  Líder: {leader?.name ?? '—'} (CHA {leader?.stats.charisma})
+                <span className="text-white/20 text-[10px]">
+                  Líder: {leader?.name ?? '—'} · CHA {leader?.stats.charisma}
                 </span>
               </div>
               <p className="text-white font-semibold text-sm leading-tight">{activeAura.name}</p>
-              <p className="text-white/45 text-xs mt-0.5 leading-relaxed">{activeAura.description}</p>
+              <p className="text-white/40 text-xs mt-0.5 leading-relaxed">{activeAura.description}</p>
             </div>
           </div>
-        ) : (
-          <div className="flex items-center gap-2 text-white/20">
-            <span className="text-base">✨</span>
-            <span className="text-xs">Selecciona Therians para ver el aura activa</span>
-          </div>
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-white/8 bg-white/2 p-3 flex items-center gap-2 text-white/20">
+          <span className="text-base">✨</span>
+          <span className="text-xs">Selecciona Therians para ver el aura del líder</span>
+        </div>
+      )}
 
       {/* Therians grid */}
-      <div className="grid grid-cols-1 gap-3">
+      <div className="space-y-2">
         {therians.map(t => {
           const archId = t.trait.id as keyof typeof ARCH_META
           const arch = ARCH_META[archId] ?? ARCH_META.forestal
@@ -168,38 +214,41 @@ export default function TeamSetup({ therians, onBattleStart }: Props) {
             <button
               key={t.id}
               onClick={() => toggleSelect(t.id)}
-              className={`w-full text-left rounded-xl border p-3 transition-all ${
+              className={`w-full text-left rounded-xl border p-3 transition-all duration-150 group ${
                 isSelected
-                  ? `${arch.border} ${arch.bg} ring-1 ring-white/10`
-                  : `${RARITY_BORDER[t.rarity]} bg-white/3 hover:bg-white/5`
+                  ? `${arch.border} ${arch.bg} shadow-[inset_0_0_0_1px_rgba(255,255,255,0.06)]`
+                  : `${RARITY_BORDER[t.rarity] ?? 'border-white/8'} bg-white/2 hover:bg-white/4 hover:border-white/15`
               }`}
             >
-              <div className="flex gap-3">
+              <div className="flex gap-3 items-start">
                 {/* Avatar */}
-                <div className="flex-shrink-0">
-                  <TherianAvatar therian={t} size={64} />
+                <div className="flex-shrink-0 mt-0.5">
+                  <TherianAvatar therian={t} size={60} />
                 </div>
 
                 {/* Info */}
                 <div className="flex-1 min-w-0 space-y-1.5">
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <span className="text-white font-semibold text-sm truncate">
-                      {t.name ?? `Therian sin nombre`}
+                      {t.name ?? t.species.name}
                     </span>
-                    <span className={`text-xs px-1.5 py-0.5 rounded-full ${arch.pill}`}>
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${arch.pill}`}>
                       {arch.emoji} {archId}
+                    </span>
+                    <span className={`text-[10px] font-medium ml-auto ${RARITY_COLORS[t.rarity] ?? 'text-white/30'}`}>
+                      {t.rarity}
                     </span>
                   </div>
 
-                  {/* Mini stats */}
-                  <div className="flex gap-3 text-xs text-white/50">
-                    <span>❤️ {t.stats.vitality}</span>
+                  {/* Stats */}
+                  <div className="flex gap-3 text-[11px] text-white/40">
+                    <span>🌿 {t.stats.vitality}</span>
                     <span>⚡ {t.stats.agility}</span>
                     <span>🌌 {t.stats.instinct}</span>
                     <span>✨ {t.stats.charisma}</span>
                   </div>
 
-                  {/* Abilities pills */}
+                  {/* Abilities */}
                   <div className="flex flex-wrap gap-1">
                     {allAbilityIds.map(id => {
                       const ab = ABILITY_BY_ID[id]
@@ -207,12 +256,12 @@ export default function TeamSetup({ therians, onBattleStart }: Props) {
                       return (
                         <span
                           key={id}
-                          className={`text-xs px-1.5 py-0.5 rounded border text-white/50 ${
+                          className={`text-[10px] px-1.5 py-0.5 rounded border ${
                             ab.isInnate
-                              ? 'border-white/20 bg-white/5'
+                              ? 'border-white/15 bg-white/5 text-white/50'
                               : ab.type === 'passive'
-                                ? 'border-white/10 bg-white/3 opacity-60'
-                                : 'border-white/15 bg-white/5'
+                                ? 'border-white/8 bg-white/3 text-white/30'
+                                : 'border-white/12 bg-white/4 text-white/45'
                           }`}
                         >
                           {ab.isInnate ? '★ ' : ab.type === 'passive' ? '(P) ' : ''}{ab.name}
@@ -220,17 +269,17 @@ export default function TeamSetup({ therians, onBattleStart }: Props) {
                       )
                     })}
                     {allAbilityIds.length === 0 && (
-                      <span className="text-xs text-white/20">Sin habilidades equipadas</span>
+                      <span className="text-[10px] text-white/20">Sin habilidades</span>
                     )}
                   </div>
                 </div>
 
-                {/* Selection indicator */}
-                <div className="flex-shrink-0 flex items-center">
+                {/* Selection dot */}
+                <div className="flex-shrink-0 flex items-center self-center">
                   <div className={`w-5 h-5 rounded-full border-2 flex items-center justify-center transition-all ${
-                    isSelected ? 'border-white/60 bg-white/20' : 'border-white/20'
+                    isSelected ? 'border-white/50 bg-white/15' : 'border-white/15'
                   }`}>
-                    {isSelected && <span className="text-white text-xs">✓</span>}
+                    {isSelected && <span className="text-white text-[10px] font-bold">✓</span>}
                   </div>
                 </div>
               </div>
@@ -239,26 +288,68 @@ export default function TeamSetup({ therians, onBattleStart }: Props) {
         })}
       </div>
 
-      {/* Error */}
-      {error && (
-        <p className="text-red-400 text-sm text-center">{error}</p>
+      {/* Messages */}
+      {(error || externalError) && (
+        <div className="rounded-xl border border-red-500/20 bg-red-500/8 px-4 py-2.5 text-red-400 text-sm text-center">
+          {error ?? externalError}
+        </div>
+      )}
+      {saveMsg && (
+        <div className={`rounded-xl border px-4 py-2.5 text-sm text-center ${
+          saveMsg.startsWith('✓')
+            ? 'border-emerald-500/20 bg-emerald-500/8 text-emerald-400'
+            : 'border-red-500/20 bg-red-500/8 text-red-400'
+        }`}>
+          {saveMsg}
+        </div>
       )}
 
-      {/* Start button */}
-      <button
-        onClick={handleStart}
-        disabled={selected.size !== 3 || loading}
-        className="w-full py-3 rounded-xl font-semibold text-white transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-gradient-to-r from-red-600/80 to-orange-600/80 hover:from-red-600 hover:to-orange-600 border border-white/10"
-      >
-        {loading ? (
-          <span className="flex items-center justify-center gap-2">
-            <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-            Buscando rival...
-          </span>
+      {/* Action buttons */}
+      <div className="space-y-2">
+        {mode === 'team-setup' ? (
+          <button
+            onClick={handleSaveTeam}
+            disabled={selected.size !== 3 || saving}
+            className="w-full py-3 rounded-xl font-semibold text-white text-sm transition-all disabled:opacity-35 disabled:cursor-not-allowed bg-gradient-to-r from-purple-700 to-indigo-700 hover:from-purple-600 hover:to-indigo-600 border border-purple-500/20 shadow-lg shadow-purple-900/20"
+          >
+            {saving ? (
+              <span className="flex items-center justify-center gap-2">
+                <span className="w-4 h-4 border-2 border-white/25 border-t-white rounded-full animate-spin" />
+                Guardando...
+              </span>
+            ) : (
+              '💾 Guardar equipo'
+            )}
+          </button>
         ) : (
-          '⚔️ Combatir'
+          <>
+            {/* Save silently available in battle mode too */}
+            {selected.size === 3 && (
+              <button
+                onClick={handleSaveTeam}
+                disabled={saving}
+                className="w-full py-2 rounded-xl text-xs font-medium text-white/30 hover:text-white/55 transition-all disabled:opacity-30 border border-white/6 bg-white/2 hover:bg-white/4"
+              >
+                {saving ? 'Guardando...' : '💾 Guardar como equipo predeterminado'}
+              </button>
+            )}
+            <button
+              onClick={handleStart}
+              disabled={selected.size !== 3 || loading}
+              className="w-full py-3.5 rounded-xl font-bold text-white text-base transition-all disabled:opacity-35 disabled:cursor-not-allowed bg-gradient-to-r from-red-700/90 to-orange-700/90 hover:from-red-600 hover:to-orange-600 border border-red-500/20 shadow-lg shadow-red-900/20"
+            >
+              {loading ? (
+                <span className="flex items-center justify-center gap-2">
+                  <span className="w-4 h-4 border-2 border-white/25 border-t-white rounded-full animate-spin" />
+                  Buscando rival...
+                </span>
+              ) : (
+                '⚔️ Combatir'
+              )}
+            </button>
+          </>
         )}
-      </button>
+      </div>
     </div>
   )
 }

--- a/components/pvp/TeamSetup.tsx
+++ b/components/pvp/TeamSetup.tsx
@@ -112,7 +112,7 @@ export default function TeamSetup({ therians, onBattleStart, savedTeamIds, onTea
       const res = await fetch('/api/pvp/start', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ attackerTeamIds: Array.from(selected) }),
+        body: JSON.stringify({ attackerTeamIds: Array.from(selected), mode: 'manual' }),
       })
       let data: Record<string, unknown> = {}
       try { data = await res.json() } catch { /* no-JSON */ }

--- a/components/spellbook/SpellbookPage.tsx
+++ b/components/spellbook/SpellbookPage.tsx
@@ -1,0 +1,327 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { ABILITIES, INNATE_ABILITIES } from '@/lib/pvp/abilities'
+import type { Ability } from '@/lib/pvp/abilities'
+import { SHOP_ITEMS } from '@/lib/shop/catalog'
+
+type ArchFilter = 'all' | 'forestal' | 'electrico' | 'acuatico' | 'volcanico'
+type TypeFilter = 'all' | 'active' | 'passive'
+
+interface InventoryEntry {
+  abilityId: string
+  quantity: number
+  equippedIn: string[]
+}
+
+const ARCH_META: Record<string, { label: string; emoji: string; text: string; border: string; bg: string; badge: string }> = {
+  forestal:  { label: 'Forestal',  emoji: '🌿', text: 'text-emerald-400', border: 'border-emerald-500/30', bg: 'bg-emerald-500/8',  badge: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30' },
+  electrico: { label: 'Eléctrico', emoji: '⚡', text: 'text-yellow-400',  border: 'border-yellow-500/30',  bg: 'bg-yellow-500/8',   badge: 'bg-yellow-500/15 text-yellow-300 border-yellow-500/30' },
+  acuatico:  { label: 'Acuático',  emoji: '💧', text: 'text-blue-400',    border: 'border-blue-500/30',    bg: 'bg-blue-500/8',     badge: 'bg-blue-500/15 text-blue-300 border-blue-500/30' },
+  volcanico: { label: 'Volcánico', emoji: '🔥', text: 'text-orange-400',  border: 'border-orange-500/30',  bg: 'bg-orange-500/8',   badge: 'bg-orange-500/15 text-orange-300 border-orange-500/30' },
+}
+
+function effectSummary(ab: Ability): string {
+  const e = ab.effect
+  const parts: string[] = []
+  if (e.damage)       parts.push(`${Math.round(e.damage * 100)}% daño`)
+  if (e.heal)         parts.push(`${Math.round(e.heal * 100)}% curación`)
+  if (e.stun)         parts.push(`Aturdimiento ${e.stun}t`)
+  if (e.shield)       parts.push(`Escudo ${e.shield} HP`)
+  if (e.dot)          parts.push(`DoT ×${e.dot.damage} × ${e.dot.turns}t`)
+  if (e.lifeSteal)    parts.push(`Roba vida ${Math.round(e.lifeSteal * 100)}%`)
+  if (e.multiHit)     parts.push(`${e.multiHit.count}× golpes`)
+  if (e.execute)      parts.push(`Ejecución <${Math.round(e.execute.threshold * 100)}% HP`)
+  if (e.stunChance)   parts.push(`${Math.round(e.stunChance * 100)}% stun`)
+  if (e.buff)         parts.push(`+${Math.round(e.buff.pct * 100)}% ${e.buff.stat} ${e.buff.turns}t`)
+  if (e.debuff)       parts.push(`-${Math.round(e.debuff.pct * 100)}% ${e.debuff.stat} rival`)
+  if (e.thorns)       parts.push(`Refleja ${Math.round(e.thorns * 100)}% daño`)
+  if (e.damageReduction) parts.push(`Reduce daño ${Math.round(e.damageReduction * 100)}%`)
+  if (e.regen)        parts.push(`+${e.regen} HP/turno`)
+  if (e.critBoost)    parts.push(`+${Math.round(e.critBoost * 100)}% crítico`)
+  if (e.immunity)     parts.push(`Inmune a ${e.immunity}`)
+  if (e.endure)       parts.push('Sobrevive golpe fatal')
+  if (e.tiebreaker)   parts.push('Actúa primero en empates')
+  return parts.join(' · ') || '—'
+}
+
+export default function SpellbookPage() {
+  const router = useRouter()
+  const [archFilter, setArchFilter] = useState<ArchFilter>('all')
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all')
+  const [search, setSearch] = useState('')
+  const [inventory, setInventory] = useState<InventoryEntry[]>([])
+  const [loadingInv, setLoadingInv] = useState(true)
+  const [buying, setBuying] = useState<string | null>(null)
+  const [buyError, setBuyError] = useState<string | null>(null)
+  const [gold, setGold] = useState<number | null>(null)
+
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/user/abilities').then(r => r.ok ? r.json() : { inventory: [] }),
+      fetch('/api/me').then(r => r.ok ? r.json() : null),
+    ]).then(([invData, meData]) => {
+      setInventory(invData.inventory ?? [])
+      if (meData?.gold !== undefined) setGold(meData.gold)
+    }).finally(() => setLoadingInv(false))
+  }, [])
+
+  // Listen for wallet updates
+  useEffect(() => {
+    const handler = () => {
+      fetch('/api/me').then(r => r.ok ? r.json() : null).then(d => {
+        if (d?.gold !== undefined) setGold(d.gold)
+      })
+    }
+    window.addEventListener('wallet-update', handler)
+    return () => window.removeEventListener('wallet-update', handler)
+  }, [])
+
+  const invMap = Object.fromEntries(inventory.map(i => [i.abilityId, i]))
+
+  const filtered = ABILITIES.filter(ab => {
+    if (archFilter !== 'all' && ab.archetype !== archFilter) return false
+    if (typeFilter !== 'all' && ab.type !== typeFilter) return false
+    if (search && !ab.name.toLowerCase().includes(search.toLowerCase())) return false
+    return true
+  })
+
+  const handleBuy = async (abilityId: string) => {
+    const shopItem = SHOP_ITEMS.find(i => i.abilityId === abilityId)
+    if (!shopItem) return
+    setBuying(abilityId)
+    setBuyError(null)
+    try {
+      const res = await fetch('/api/shop/buy', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ itemId: shopItem.id }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        if (data.error === 'INSUFFICIENT_ESSENCIA') setBuyError('Oro insuficiente.')
+        else setBuyError(data.error ?? 'Error al comprar.')
+        return
+      }
+      // Update inventory
+      setInventory(prev => {
+        const existing = prev.find(i => i.abilityId === abilityId)
+        if (existing) {
+          return prev.map(i => i.abilityId === abilityId ? { ...i, quantity: i.quantity + 1 } : i)
+        }
+        return [...prev, { abilityId, quantity: 1, equippedIn: [] }]
+      })
+      if (data.newBalance?.gold !== undefined) {
+        setGold(data.newBalance.gold)
+        window.dispatchEvent(new CustomEvent('wallet-update'))
+      }
+    } catch {
+      setBuyError('Error de conexión.')
+    } finally {
+      setBuying(null)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[#08080F] text-white">
+      {/* Header */}
+      <div className="sticky top-0 z-20 bg-[#08080F]/90 backdrop-blur-md border-b border-white/8 px-4 py-3">
+        <div className="max-w-4xl mx-auto flex items-center justify-between gap-3 flex-wrap">
+          <div className="flex items-center gap-3">
+            <Link href="/therian" className="text-white/40 hover:text-white/70 transition-colors text-sm">← Inicio</Link>
+            <h1 className="text-lg font-bold text-white">📖 Libro de Hechizos</h1>
+          </div>
+          <div className="flex items-center gap-3">
+            {gold !== null && (
+              <span className="text-amber-400 text-sm font-semibold">🪙 {gold.toLocaleString()}</span>
+            )}
+            <input
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder="Buscar..."
+              className="bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder-white/25 outline-none focus:border-white/25 w-36"
+            />
+          </div>
+        </div>
+
+        {/* Filters */}
+        <div className="max-w-4xl mx-auto flex gap-2 mt-3 flex-wrap">
+          {/* Archetype filter */}
+          {(['all', 'forestal', 'electrico', 'acuatico', 'volcanico'] as ArchFilter[]).map(arch => {
+            const meta = arch === 'all' ? null : ARCH_META[arch]
+            const active = archFilter === arch
+            return (
+              <button
+                key={arch}
+                onClick={() => setArchFilter(arch)}
+                className={`px-3 py-1 rounded-full text-xs font-semibold border transition-all ${
+                  active
+                    ? meta
+                      ? `${meta.badge} border`
+                      : 'bg-white/15 text-white border-white/30'
+                    : 'bg-transparent text-white/40 border-white/10 hover:text-white/60 hover:border-white/20'
+                }`}
+              >
+                {meta ? `${meta.emoji} ${meta.label}` : 'Todas'}
+              </button>
+            )
+          })}
+
+          <div className="w-px bg-white/10 self-stretch mx-1" />
+
+          {/* Type filter */}
+          {([['all', 'Todas'], ['active', 'Activas'], ['passive', 'Pasivas']] as [TypeFilter, string][]).map(([t, label]) => (
+            <button
+              key={t}
+              onClick={() => setTypeFilter(t)}
+              className={`px-3 py-1 rounded-full text-xs font-semibold border transition-all ${
+                typeFilter === t
+                  ? 'bg-white/15 text-white border-white/30'
+                  : 'bg-transparent text-white/40 border-white/10 hover:text-white/60 hover:border-white/20'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-4xl mx-auto px-4 py-6">
+        {buyError && (
+          <div className="mb-4 text-red-400 text-xs text-center bg-red-500/10 border border-red-500/20 rounded-lg py-2 px-3">
+            {buyError}
+          </div>
+        )}
+
+        {loadingInv ? (
+          <div className="text-white/20 text-center py-20 text-sm">Cargando...</div>
+        ) : filtered.length === 0 ? (
+          <div className="text-white/20 text-center py-20 text-sm">No hay habilidades que coincidan.</div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {filtered.map(ab => {
+              const meta = ARCH_META[ab.archetype]
+              const shopItem = SHOP_ITEMS.find(i => i.abilityId === ab.id)
+              const inv = invMap[ab.id]
+              const owned = inv?.quantity ?? 0
+              const equippedCount = inv?.equippedIn.length ?? 0
+              const isBuying = buying === ab.id
+
+              return (
+                <div
+                  key={ab.id}
+                  className={`rounded-2xl border bg-white/3 backdrop-blur-sm p-4 flex flex-col gap-3 transition-all ${
+                    owned > 0 ? `${meta.border}` : 'border-white/8'
+                  }`}
+                >
+                  {/* Top row */}
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className={`text-sm font-bold ${owned > 0 ? meta.text : 'text-white/70'}`}>
+                          {ab.name}
+                        </span>
+                        {/* Type badge */}
+                        <span className={`text-[9px] uppercase tracking-widest font-semibold px-1.5 py-0.5 rounded border ${
+                          ab.type === 'passive'
+                            ? 'border-purple-500/30 text-purple-400 bg-purple-500/10'
+                            : 'border-white/15 text-white/40 bg-white/5'
+                        }`}>
+                          {ab.type === 'passive' ? 'Pasiva' : 'Activa'}
+                        </span>
+                      </div>
+                      {/* Archetype + CD */}
+                      <div className="flex items-center gap-2 mt-1 flex-wrap">
+                        <span className={`text-[10px] font-semibold ${meta.text}`}>{meta.emoji} {meta.label}</span>
+                        {ab.type === 'active' && (
+                          <span className="text-white/25 text-[10px]">
+                            CD: {ab.cooldown === 0 ? '—' : `${ab.cooldown}t`}
+                            {' · '}
+                            {ab.target === 'self' ? 'Propio' : ab.target === 'ally' ? 'Aliado' : 'Rival'}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Owned badge */}
+                    {owned > 0 && (
+                      <div className={`text-xs font-bold px-2 py-1 rounded-lg border ${meta.badge} flex-shrink-0`}>
+                        ×{owned}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Effect summary */}
+                  <p className="text-white/40 text-[11px] leading-relaxed">
+                    {effectSummary(ab)}
+                  </p>
+
+                  {/* Bottom row */}
+                  <div className="flex items-center justify-between gap-2 mt-auto pt-1 border-t border-white/6">
+                    {/* Equipped info + equip link */}
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-[10px] text-white/25">
+                        {owned === 0
+                          ? 'No poseída'
+                          : equippedCount > 0
+                            ? `Equipada en ${equippedCount} Therian${equippedCount > 1 ? 's' : ''}`
+                            : `Disponible (${owned - equippedCount} libre${owned - equippedCount > 1 ? 's' : ''})`
+                        }
+                      </span>
+                      {owned > 0 && owned - equippedCount > 0 && (
+                        <Link
+                          href="/therian"
+                          className={`text-[9px] font-semibold px-1.5 py-0.5 rounded border transition-colors ${meta.badge} opacity-70 hover:opacity-100`}
+                        >
+                          → Equipar
+                        </Link>
+                      )}
+                    </div>
+
+                    {/* Buy button */}
+                    {shopItem && (
+                      <button
+                        onClick={() => handleBuy(ab.id)}
+                        disabled={isBuying}
+                        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-[11px] font-semibold transition-all disabled:opacity-40 ${
+                          owned === 0
+                            ? 'border-amber-500/40 bg-amber-500/10 text-amber-300 hover:bg-amber-500/20 hover:border-amber-500/60'
+                            : 'border-white/10 bg-white/5 text-white/50 hover:bg-white/8 hover:border-white/20'
+                        }`}
+                      >
+                        <span>🪙 {shopItem.costGold.toLocaleString()}</span>
+                        <span className="text-white/30">·</span>
+                        <span>{isBuying ? '...' : owned > 0 ? '+1 copia' : 'Comprar'}</span>
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Innate abilities note */}
+        <div className="mt-8 border-t border-white/6 pt-6">
+          <h2 className="text-white/30 text-xs uppercase tracking-widest font-semibold mb-3">
+            Habilidades Innatas (no equipables)
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            {INNATE_ABILITIES.map(ab => {
+              const meta = ARCH_META[ab.archetype]
+              return (
+                <div key={ab.id} className={`rounded-xl border ${meta.border} ${meta.bg} px-3 py-2`}>
+                  <div className={`text-[11px] font-semibold ${meta.text}`}>{meta.emoji} {ab.name}</div>
+                  <div className="text-white/25 text-[10px] mt-0.5">{meta.label} · Siempre activa</div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -102,58 +102,114 @@ Interfaz para ver y equipar runas. Muestra el inventario de runas del Therian y 
 
 ## PvP — Componentes
 
+### PvpPageClient (`components/pvp/PvpPageClient.tsx`)
+
+Lobby PvP completo. Gestiona:
+- **Vistas**: `'lobby'` | `'fight'` | `'team'`
+- Carga energía, MMR y equipo guardado al montar (`GET /api/pvp/status`, `GET /api/pvp/team`)
+- Sidebar con stats del jugador: energía `⚡ N/10`, MMR, rango, victorias semanales
+- Si no hay equipo guardado → botón "🛡️ Configura tu equipo" (redirige a vista team)
+- Si hay equipo → botón "⚔️ Batalla Clasificatoria" (inicia batalla directamente)
+- Pasa `initialTeamIds` a `PvpRoom` para omitir TeamSetup
+
+---
+
 ### PvpRoom (`components/pvp/PvpRoom.tsx`)
 
-Orquestador de estados del PvP:
+Orquestador de fases del PvP:
 
 ```typescript
-type Phase = 'setup' | 'loading_battle' | 'battle' | 'result'
+type Phase = 'setup' | 'starting' | 'loading_battle' | 'battle' | 'result'
 ```
 
-- `setup` → `TeamSetup`
-- `loading_battle` → spinner mientras carga batalla activa
-- `battle` → `BattleField`
-- `result` → pantalla de victoria/derrota
+| Fase | Qué muestra | Cuándo |
+|------|-------------|--------|
+| `setup` | `TeamSetup` | Sin equipo / error de inicio |
+| `starting` | Spinner "Buscando rival…" | Auto-llama `POST /api/pvp/start` con equipo guardado |
+| `loading_battle` | Spinner "Cargando batalla…" | Hay `activeBattleId` al montar |
+| `battle` | `BattleField` | Batalla en curso |
+| `result` | Pantalla victoria/derrota + recompensas | Batalla terminada |
 
-Al montar, verifica si hay una batalla activa (`activeBattleId` prop) y la carga vía `GET /api/pvp/[id]`.
+Props clave:
+- `initialTeamIds?: string[]` — si se pasan 3 IDs, salta a `'starting'` y auto-llama la API
+- `onBattleComplete?(won, rewards)` — callback para el lobby
+- `savedTeamIds?, onTeamSaved?` — persistencia del equipo
+- `externalError` — errores propagados a `TeamSetup`
 
 ---
 
 ### TeamSetup (`components/pvp/TeamSetup.tsx`)
 
-Selección del equipo de 3 Therians:
-- Grid de cards seleccionables (borde colored al seleccionar)
+Dos modos de operación:
+
+| Modo | Botón principal | Descripción |
+|------|-----------------|-------------|
+| `'team-setup'` | 💾 Guardar equipo | Solo guarda el equipo predeterminado |
+| `'battle'` | ⚔️ Combatir | Guarda equipo + inicia batalla |
+
+- Grid de cards seleccionables con borde de color por arquetipo
 - Contador "X/3 seleccionados"
 - Muestra arquetipo, stats y habilidades equipadas
-- Botón "⚔️ Combatir" (disabled < 3) → `POST /api/pvp/start`
+- `externalError?: string` — muestra errores venidos de la fase `'starting'`
 
 ---
 
 ### BattleField (`components/pvp/BattleField.tsx`)
 
-Arena de combate. Estructura:
+Arena de combate pre-computada con 4 fases visuales.
 
 ```
 ┌─────────────────────────────────────┐
-│  COLA DE TURNOS (6 chips)           │
-├────────────────┬────────────────────┤
-│  TU EQUIPO     │   RIVAL            │
-│  Avatar + HP   │  Avatar + HP       │  × 3
+│  Ronda N  [⚔️ T+1/Total]  [1× 2× 4× ⏭] │
+│  ▓▓▓▓▓▓░░░░  barra de progreso     │
 ├─────────────────────────────────────┤
-│  HABILIDADES (turno propio)         │
+│  TU EQUIPO      VS      RIVAL       │  ← Phase 1: Arena
+│  HP bar                   HP bar   │
+│  Avatar →         ← Avatar (flip) │  × 3 por lado
+│  Nombre               Nombre      │
+│  [●●] dots         dots [●●]      │  ← Phase 4: inspección
 ├─────────────────────────────────────┤
-│  LOG (últimas 4 entradas)           │
+│  Orden: [🌿][⚡][💧] vs [🔥][💧][🌿]│
+├─────────────────────────────────────┤
+│  🌿 Zarpazo de Raíz  ATAQUE        │  ← Phase 2: Ability card
+│  Daño base ×1.0      Lobo › 35 dmg │
+├─────────────────────────────────────┤
+│  Registro (últimas 4 entradas)      │
 └─────────────────────────────────────┘
 ```
 
-**Flujo de un turno animado:**
+**Phase 1 — Arena layout:**
+- Panel `bg-[#080810]` con gradientes laterales (azul atacante / rojo defensor)
+- Therians atacantes a la izquierda, defensores a la derecha con `scaleX(-1)` (cara a cara)
+- `ArenaSlot`: barra HP → avatar (con floats) → nombre → dots
 
-1. Recibir `snapshots[]` del servidor
-2. Para cada snapshot (200ms delay entre ellos):
-   a. Ejecutar animación WAAPI de ataque
-   b. Aplicar flash/shake al objetivo
-   c. Actualizar HP bars y estado visual
-3. Al terminar todos los snapshots → mostrar habilidades del jugador
+**Phase 2 — Active ability card:**
+- Se actualiza en cada turno: emoji de arquetipo, nombre, badge ATAQUE/CURA/EFECTO/PASIVO, descripción por `describeAbility()`, actor y resultado
+
+**Phase 3 — Floating damage numbers:**
+- Al impacto: números `@keyframes floatUp` sobre el avatar objetivo
+- Rojo = daño, Ámbar = bloqueado (`✦N`), Verde = curación, Púrpura = stun
+- Auto-limpian tras 1.2 s
+
+**Phase 4 — Ability inspection dots:**
+- Dots de arquetipo por habilidad equipada en cada slot
+- `title` muestra `Nombre: descripción` al pasar el cursor
+
+**Funciones puras exportadas (testables):**
+
+```typescript
+describeAbility(ab: Ability): string
+// "Daño base ×0.8. Aturde 1 turno"
+
+hpBarColor(current: number, max: number): 'bg-emerald-500' | 'bg-amber-500' | 'bg-red-500'
+// >60% verde, >30% ámbar, ≤30% rojo
+
+resultLines(entry: ActionLogEntry): string[]
+// ["35 daño"] / ["+22 HP"] / ["Aturdido: saltea turno"]
+
+applySnapshot(base: BattleState, snap: TurnSnapshot): BattleState
+// Retorna nuevo BattleState sin mutar el original
+```
 
 ---
 
@@ -165,47 +221,28 @@ Las animaciones de batalla usan el **Web Animations API** (`element.animate()`) 
 
 CSS class toggling para re-trigger de keyframes es poco confiable en React 18 (concurrent mode puede batching renders, cancelando la transición). `element.animate()` es imperativo y siempre funciona.
 
-### Implementación
-
-```typescript
-// En BattleField — useEffect reacciona a animInfo
-useEffect(() => {
-  if (!animInfo) return
-  const { actorId, targetIds, actorSide, isHeal } = animInfo
-
-  // 1. Elevar z-index del atacante para que vuele por encima
-  const actorCard = cardRefs.current.get(actorId)
-  if (actorCard) {
-    actorCard.style.zIndex = '50'
-    setTimeout(() => { actorCard.style.zIndex = '' }, 750)
-  }
-
-  // 2. Flash blanco en el atacante
-  actorCard?.animate([
-    { boxShadow: '0 0 0 2px rgba(255,255,255,0.7), 0 0 20px rgba(255,255,255,0.3)' },
-    { boxShadow: 'none' },
-  ], { duration: 450 })
-
-  // 3. Vuelo cross-battlefield usando getBoundingClientRect()
-  const avatarEl = avatarRefs.current.get(actorId)
-  // calcular dx, dy desde centroide del actor hasta centroide(s) del/los objetivo(s)
-  // ... (ver código fuente en BattleField.tsx)
-
-  // 4. Flash/shake en objetivos (sincronizado con el impacto a offset 0.50)
-  const impactDelay = Math.round(animDuration * 0.46)
-  for (const targetId of targetIds) {
-    cardRefs.current.get(targetId)?.animate([/* red/green flash */], { delay: impactDelay })
-  }
-}, [animInfo])
-```
-
-### Refs de elementos DOM
+### Refs de DOM
 
 `BattleField` mantiene dos `Map<string, HTMLDivElement>`:
-- `cardRefs` — card contenedora de cada slot
-- `avatarRefs` — elemento del avatar (con `willChange: 'transform'`)
+- `cardRefs` — card contenedora de cada `ArenaSlot`
+- `avatarRefs` — wrapper WAAPI del avatar (**sin** mirror)
 
-Los `SlotCard` children los registran via props `onCardRef` / `onAvatarRef`.
+El mirror visual (`scaleX(-1)`) se aplica en un div **hijo** del `avatarRef`, de forma que WAAPI puede trasladar el elemento y el flip visual se mantiene compuesto correctamente.
+
+### Secuencia por turno
+
+```
+1. Flash blanco en card del actor
+2. avatarEl.animate() → vuelo hacia el centroide del/los objetivo(s)
+3. Al impacto (offset 0.50): flash rojo/verde en card del objetivo
+4. Si daño: shake horizontal en card del objetivo
+5. Floats de números suben y desaparecen (1.2 s)
+6. HP bars actualizadas con transition-all duration-700
+```
+
+### Floating numbers
+
+Estado `floatNums: Map<therianId, FloatNum[]>`. Se generan al procesar cada snapshot y se limpian con `setTimeout` de 1200 ms. El keyframe `floatUp` está en un `<style>` inline del componente (no requiere cambios en `globals.css`).
 
 ---
 

--- a/docs/pvp.md
+++ b/docs/pvp.md
@@ -7,27 +7,66 @@ El sistema de combate por turnos enfrenta al equipo del jugador (3 Therians) con
 - `lib/pvp/abilities.ts` — catálogo de habilidades
 - `lib/pvp/engine.ts` — motor de combate (puro, sin DB)
 - `lib/pvp/ai.ts` — decisiones de la IA
+- `lib/pvp/energy.ts` — lógica de regeneración de energía
+- `lib/pvp/mmr.ts` — sistema de MMR, rangos y recompensas
 - `lib/catalogs/auras.ts` — catálogo de 40 auras
 - `app/api/pvp/start/route.ts` — crear batalla
 - `app/api/pvp/[id]/route.ts` — estado actual
-- `app/api/pvp/[id]/action/route.ts` — ejecutar acción
+- `app/api/pvp/[id]/action/route.ts` — ejecutar todos los turnos (pre-computado)
+- `app/api/pvp/team/route.ts` — guardar/leer equipo predeterminado
+- `app/api/pvp/status/route.ts` — energía, MMR y recompensas disponibles
+- `app/api/pvp/ranking/route.ts` — ranking global top 10 por MMR
+- `app/api/pvp/rewards/weekly/route.ts` — cofre semanal (GET + POST)
+- `app/api/pvp/rewards/monthly/route.ts` — recompensa mensual (GET + POST)
 - `app/api/therian/equip-abilities/route.ts` — equipar habilidades
-- `components/pvp/BattleField.tsx` — interfaz de la arena
-- `components/pvp/TeamSetup.tsx` — selección de equipo (muestra aura activa)
+- `components/pvp/PvpPageClient.tsx` — lobby completo
+- `components/pvp/PvpRoom.tsx` — orquestador de fases
+- `components/pvp/BattleField.tsx` — arena visual 4 fases (pre-computada)
+- `components/pvp/TeamSetup.tsx` — selección/guardado de equipo
+- `lib/pvp/__test__/pvp-full.test.ts` — 287+ tests del motor
+- `lib/pvp/__test__/battlefield-ui.test.ts` — 77 tests de la UI de arena
 
 ---
 
 ## Flujo general
 
+El sistema usa batallas **pre-computadas**: el servidor resuelve *todos* los turnos en una sola llamada y devuelve el array completo de snapshots. El cliente los reproduce con delays para la animación visual, pero la batalla ya está resuelta.
+
 ```
-1. TeamSetup → seleccionar 3 Therians
-2. POST /api/pvp/start → { battleId, state }
-3. BattleField muestra estado inicial
-4. Si turno del jugador → mostrar habilidades
-5. POST /api/pvp/[id]/action → { snapshots[], state }
-6. BattleField reproduce snapshots animados (200ms delay entre turnos)
-7. Repetir hasta state.status === 'completed'
-8. Mostrar pantalla de resultado (victoria/derrota)
+Lobby (PvpPageClient)
+  ├── Sin equipo guardado → "Configura tu equipo" (redirige a TeamSetup)
+  └── Con equipo guardado (3 IDs)
+       ├── Verificar energía (⚡ 0–10)
+       └── Clic "Batalla Clasificatoria"
+             │
+             ▼
+  PvpRoom — fase: 'starting'
+    └── POST /api/pvp/start { attackerTeamIds }
+          │ servidor resuelve TODOS los turnos
+          ▼
+  PvpRoom — fase: 'battle'
+    └── BattleField reproduce snapshots animados
+          │ velocidad configurable (1× / 2× / 4×)
+          ▼
+  PvpRoom — fase: 'result'
+    └── Pantalla victoria/derrota + MMR delta + oro ganado
+```
+
+### Gestión del equipo predeterminado
+
+El usuario guarda un equipo de 3 Therians en su perfil (`savedPvpTeam` en User). Este equipo se usa automáticamente al iniciar batalla. Si uno de los Therians del equipo guardado ya no está activo (fusionado, liberado), se filtra y el equipo queda incompleto hasta que el usuario lo actualice.
+
+```
+GET /api/pvp/team  → { teamIds, therians[] }
+POST /api/pvp/team { teamIds: [id1, id2, id3] } → { ok, teamIds }
+```
+
+### Energía PvP
+
+Cada batalla consume 1 energía. La energía se regenera automáticamente a razón de 1 unidad cada 2 horas, hasta un máximo de 10. Si `pvpEnergy = 0`, no se puede iniciar batalla.
+
+```
+GET /api/pvp/status → { energy, energyMax, energyRegenAt, mmr, rank, ... }
 ```
 
 ---
@@ -379,6 +418,93 @@ Los slots se ordenan al inicio por `effectiveAgility` descendente. El orden no c
 
 ## Persistencia
 
-`PvpBattle.state` almacena el `BattleState` serializado como JSON. Tras cada acción del jugador, se actualiza con el nuevo estado completo. Las batallas completadas permanecen en DB (status `'completed'`).
+`PvpBattle.state` almacena el `BattleState` serializado como JSON. Tras cada llamada a `/api/pvp/[id]/action`, se actualiza con el estado final. Las batallas completadas permanecen en DB (status `'completed'`).
 
 Un usuario solo puede tener **una batalla activa** a la vez. Si existe una al cargar `/pvp`, se recarga automáticamente.
+
+---
+
+## Sistema MMR y Rangos
+
+El MMR (Match Making Rating) determina el rango competitivo del usuario.
+
+| Rango | MMR mínimo |
+|-------|------------|
+| Bronce | 0 |
+| Plata | 600 |
+| Oro | 1000 |
+| Platino | 1400 |
+| Diamante | 1800 |
+| Maestro | 2200 |
+
+### Variación de MMR por batalla
+
+```
+Victoria: +20 MMR  (−5 si el oponente tiene mucho menos MMR)
+Derrota:  −15 MMR  (mínimo 0)
+Oro ganado por victoria: 50–100 gold según rango del rival
+```
+
+### Ranking
+
+`GET /api/pvp/ranking` devuelve el top 10 global por MMR + la posición del usuario autenticado si no está en el top.
+
+```json
+{
+  "entries": [
+    { "position": 1, "name": "Usuario", "mmr": 2500, "rank": "Maestro", "isCurrentUser": false }
+  ],
+  "currentUser": { "position": 15, "mmr": 1200, "rank": "Oro", "isCurrentUser": true }
+}
+```
+
+---
+
+## Sistema de Recompensas
+
+### Cofre Semanal
+
+Al acumular **15 victorias en la semana**, se desbloquea el cofre semanal (claimable una vez por período).
+
+`GET /api/pvp/rewards/weekly` — Estado del cofre (disponible, ya reclamado, victorias actuales).
+
+`POST /api/pvp/rewards/weekly` — Reclamar cofre. Otorga:
+- 800 gold
+- 1 huevo (tier según rango)
+- 2 runas aleatorias del pool T1
+
+```json
+{ "gold": 800, "egg": "egg_rare", "runes": ["v_1", "a_2"] }
+```
+
+**Errores:**
+| Código | Status |
+|--------|--------|
+| `NOT_ENOUGH_WINS` | 400 — victorias insuficientes |
+| `ALREADY_CLAIMED` | 409 — ya reclamado en este período |
+
+### Recompensa Mensual
+
+Al inicio de cada mes se puede reclamar una recompensa basada en el **rango pico** alcanzado durante el mes.
+
+`GET /api/pvp/rewards/monthly` — Estado de la recompensa mensual.
+
+`POST /api/pvp/rewards/monthly` — Reclamar recompensa mensual.
+
+---
+
+## Tests
+
+```bash
+# Motor de combate (287+ tests)
+npx tsx lib/pvp/__test__/pvp-full.test.ts
+
+# UI de arena — funciones puras (77 tests)
+npx tsx lib/pvp/__test__/battlefield-ui.test.ts
+```
+
+Los tests de battlefield-ui cubren:
+- `describeAbility()` — descripción legible para los 16 tipos de efecto
+- `hpBarColor()` — umbrales de color de barra de HP
+- `resultLines()` — formateo de resultados de turno
+- `applySnapshot()` — aplicación correcta de snapshots con edge cases

--- a/lib/pvp/__test__/battlefield-ui.test.ts
+++ b/lib/pvp/__test__/battlefield-ui.test.ts
@@ -60,11 +60,13 @@ function makeSlot(overrides: Partial<TurnSlot> = {}): TurnSlot {
     instinct: 20,
     charisma: 20,
     equippedAbilities: [],
+    equippedPassives: [],
     innateAbilityId: 'basic_forestal',
     cooldowns: {},
     effects: [],
     isDead: false,
     shieldHp: 0,
+    endureUsed: false,
     isLeader: false,
     ...overrides,
   }
@@ -143,10 +145,10 @@ section('Phase 1 — describeAbility()')
 }
 
 {
-  const ab = ABILITY_BY_ID['acu_tsun'] // Tsunami: damage 0.6
-  assert(!!ab, 'acu_tsun exists in ABILITY_BY_ID')
+  const ab = ABILITY_BY_ID['acu_corriente'] // Corriente Gélida: damage 1.2 + debuff agility
+  assert(!!ab, 'acu_corriente exists in ABILITY_BY_ID')
   const desc = describeAbility(ab)
-  assert(desc.includes('Daño base ×0.6'), 'Tsunami shows correct damage multiplier')
+  assert(desc.includes('Daño base ×1.2'), 'acu_corriente shows correct damage multiplier')
 }
 
 // Heal abilities
@@ -365,10 +367,10 @@ section('Phase 2 — resultLines()')
   assert(lines[0].includes('Agility reducida 25%'), 'effect text passed through')
 }
 
-// Multi-target AoE — should include total line
+// Multi-target — should include total line
 {
   const entry = makeLogEntry({
-    abilityId: 'vol_erup',
+    abilityId: 'vol_golpe',
     targetIds: ['d1', 'd2', 'd3'],
     results: [
       { targetId: 'd1', targetName: null, blocked: false, damage: 20, died: false },
@@ -383,7 +385,7 @@ section('Phase 2 — resultLines()')
 // Multi-target with some blocked
 {
   const entry = makeLogEntry({
-    abilityId: 'acu_tsun',
+    abilityId: 'acu_burbuja',
     targetIds: ['d1', 'd2'],
     results: [
       { targetId: 'd1', targetName: null, blocked: false, damage: 15, died: false },

--- a/lib/pvp/__test__/battlefield-ui.test.ts
+++ b/lib/pvp/__test__/battlefield-ui.test.ts
@@ -1,0 +1,567 @@
+/**
+ * Tests para las funciones puras de BattleField.tsx
+ * Ejecutar con:  npx tsx lib/pvp/__test__/battlefield-ui.test.ts
+ *
+ * Cubre:
+ *  ✓ Phase 1 — describeAbility: descripción legible para cada tipo de efecto
+ *  ✓ Phase 1 — hpBarColor: colores correctos por umbral de HP
+ *  ✓ Phase 2 — resultLines: líneas de resultado desde ActionLogEntry
+ *  ✓ Phase 3 — float number label generation (through resultLines)
+ *  ✓ General — applySnapshot: aplica snapshots correctamente con edge cases
+ */
+
+import { describeAbility, hpBarColor, resultLines, applySnapshot } from '../../../components/pvp/BattleField'
+import { ABILITY_BY_ID, INNATE_ABILITIES, ABILITIES } from '../abilities'
+import type { Ability, BattleState, TurnSnapshot, ActionLogEntry, TurnSlot } from '../types'
+
+// ─── Test runner ──────────────────────────────────────────────────────────────
+
+let passed = 0
+let failed = 0
+
+function assert(condition: boolean, msg: string) {
+  if (condition) {
+    console.log(`  ✓ ${msg}`)
+    passed++
+  } else {
+    console.error(`  ✗ FAIL: ${msg}`)
+    failed++
+  }
+}
+
+function assertEq<T>(a: T, b: T, msg: string) {
+  const ok = JSON.stringify(a) === JSON.stringify(b)
+  if (ok) {
+    console.log(`  ✓ ${msg}`)
+    passed++
+  } else {
+    console.error(`  ✗ FAIL: ${msg}\n    got:      ${JSON.stringify(a)}\n    expected: ${JSON.stringify(b)}`)
+    failed++
+  }
+}
+
+function section(name: string) {
+  console.log(`\n═══ ${name} ═══`)
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSlot(overrides: Partial<TurnSlot> = {}): TurnSlot {
+  return {
+    therianId: 'slot-1',
+    side: 'attacker',
+    archetype: 'forestal',
+    name: 'TestSlot',
+    currentHp: 100,
+    maxHp: 100,
+    baseAgility: 20,
+    effectiveAgility: 20,
+    vitality: 30,
+    instinct: 20,
+    charisma: 20,
+    equippedAbilities: [],
+    innateAbilityId: 'basic_forestal',
+    cooldowns: {},
+    effects: [],
+    isDead: false,
+    shieldHp: 0,
+    isLeader: false,
+    ...overrides,
+  }
+}
+
+function makeBattleState(slots: Partial<TurnSlot>[] = []): BattleState {
+  const defaultSlots = [
+    makeSlot({ therianId: 'a1', side: 'attacker', currentHp: 80, maxHp: 100 }),
+    makeSlot({ therianId: 'a2', side: 'attacker', currentHp: 50, maxHp: 100 }),
+    makeSlot({ therianId: 'd1', side: 'defender', currentHp: 100, maxHp: 120 }),
+  ]
+  return {
+    slots: slots.length ? slots.map(makeSlot) : defaultSlots,
+    turnIndex: 0,
+    round: 1,
+    auras: [],
+    auraState: {
+      attacker: {
+        resurrectionUsed: false, avatarUsed: false, ceniCegadoraUsed: false,
+        fallenCount: 0, tideSurge: 0, llamaradaTurns: 0, circuitoStacks: 0,
+        lastAbilityArch: null, shieldLastRefresh: 0, velocidadActive: false, tormentaTargetId: null,
+      },
+      defender: {
+        resurrectionUsed: false, avatarUsed: false, ceniCegadoraUsed: false,
+        fallenCount: 0, tideSurge: 0, llamaradaTurns: 0, circuitoStacks: 0,
+        lastAbilityArch: null, shieldLastRefresh: 0, velocidadActive: false, tormentaTargetId: null,
+      },
+    },
+    log: [],
+    status: 'active',
+    winnerId: null,
+  }
+}
+
+function makeLogEntry(overrides: Partial<ActionLogEntry> = {}): ActionLogEntry {
+  return {
+    turn: 1,
+    actorId: 'a1',
+    actorName: 'Lobo',
+    abilityId: 'basic_forestal',
+    abilityName: 'Zarpazo de Raíz',
+    targetIds: ['d1'],
+    results: [],
+    ...overrides,
+  }
+}
+
+function makeSnapshot(overrides: Partial<TurnSnapshot> = {}): TurnSnapshot {
+  return {
+    actorIndex: 0,
+    turnIndex: 1,
+    round: 1,
+    slots: [
+      { therianId: 'a1', currentHp: 75, maxHp: 100, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 20 },
+      { therianId: 'a2', currentHp: 50, maxHp: 100, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 20 },
+      { therianId: 'd1', currentHp: 85, maxHp: 120, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 18 },
+    ],
+    logEntry: makeLogEntry(),
+    status: 'active',
+    winnerId: null,
+    ...overrides,
+  }
+}
+
+// ─── Phase 1: describeAbility ─────────────────────────────────────────────────
+
+section('Phase 1 — describeAbility()')
+
+// Basic attacks (damage multiplier)
+{
+  const ab = ABILITY_BY_ID['basic_forestal']
+  assert(!!ab, 'basic_forestal exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('Daño base'), 'basic_forestal describes damage')
+  assert(desc.includes('×1'), 'basic_forestal shows ×1.0 multiplier')
+}
+
+{
+  const ab = ABILITY_BY_ID['acu_tsun'] // Tsunami: damage 0.6
+  assert(!!ab, 'acu_tsun exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('Daño base ×0.6'), 'Tsunami shows correct damage multiplier')
+}
+
+// Heal abilities
+{
+  const ab = ABILITY_BY_ID['for_regen'] // Regeneración: heal 1.0
+  assert(!!ab, 'for_regen exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('Curación base'), 'for_regen describes healing')
+  assert(desc.includes('×1'), 'for_regen shows ×1.0 heal multiplier')
+}
+
+{
+  const ab = ABILITY_BY_ID['acu_marea'] // Marea Curativa: heal 1.0, target ally
+  assert(!!ab, 'acu_marea exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('Curación base'), 'acu_marea describes healing')
+}
+
+// Stun + damage combo
+{
+  const ab = ABILITY_BY_ID['ele_rayo'] // Rayo Paralizante: damage 0.8, stun 1
+  assert(!!ab, 'ele_rayo exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('Daño base'), 'ele_rayo describes damage')
+  assert(desc.includes('Aturde 1 turno'), 'ele_rayo describes stun (singular)')
+}
+
+// Buff (agility)
+{
+  const ab = ABILITY_BY_ID['ele_sobre'] // Sobrecarga: buff agility +30% 2t
+  assert(!!ab, 'ele_sobre exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('+30%'), 'ele_sobre shows +30%')
+  assert(desc.includes('agility'), 'ele_sobre shows stat name')
+  assert(desc.includes('2 turnos'), 'ele_sobre shows turn count')
+}
+
+// Debuff (agility)
+{
+  const ab = ABILITY_BY_ID['for_enred'] // Enredadera: debuff agility -25% 2t
+  assert(!!ab, 'for_enred exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('-25%'), 'for_enred shows -25%')
+  assert(desc.includes('agility'), 'for_enred shows stat name')
+}
+
+// Debuff (damage)
+{
+  const ab = ABILITY_BY_ID['vol_intim'] // Intimidar: debuff damage -20% 2t
+  assert(!!ab, 'vol_intim exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('-20%'), 'vol_intim shows -20%')
+  assert(desc.includes('damage'), 'vol_intim shows damage stat')
+}
+
+// Reflect passive
+{
+  const ab = ABILITY_BY_ID['for_espinas'] // Espinas: reflect 0.15
+  assert(!!ab, 'for_espinas exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('Refleja 15%'), 'for_espinas shows 15% reflect')
+}
+
+{
+  const ab = ABILITY_BY_ID['vol_aura'] // Aura Ígnea: reflect 0.20
+  assert(!!ab, 'vol_aura exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('Refleja 20%'), 'vol_aura shows 20% reflect')
+}
+
+// Damage reduction passive
+{
+  const ab = ABILITY_BY_ID['acu_fluid'] // Fluidez: damageReduction 0.15
+  assert(!!ab, 'acu_fluid exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('Reduce 15%'), 'acu_fluid shows 15% damage reduction')
+}
+
+// Tiebreaker passive
+{
+  const ab = ABILITY_BY_ID['ele_cond'] // Conductividad: tiebreaker true
+  assert(!!ab, 'ele_cond exists in ABILITY_BY_ID')
+  const desc = describeAbility(ab)
+  assert(desc.includes('Actúa primero en empates'), 'ele_cond shows tiebreaker text')
+}
+
+// Empty effect → empty string
+{
+  const fakeAb: Ability = {
+    id: 'fake', name: 'Fake', archetype: 'forestal', type: 'passive', cooldown: 0, target: 'self', effect: {}
+  }
+  const desc = describeAbility(fakeAb)
+  assertEq(desc, '', 'empty effect produces empty string')
+}
+
+// Multi-effect: damage + stun
+{
+  const ab: Ability = {
+    id: 'test_multi',
+    name: 'Multi',
+    archetype: 'electrico',
+    type: 'active',
+    cooldown: 3,
+    target: 'single',
+    effect: { damage: 1.2, stun: 2 },
+  }
+  const desc = describeAbility(ab)
+  assert(desc.includes('Daño base ×1.2'), 'multi-effect includes damage')
+  assert(desc.includes('Aturde 2 turnos'), 'multi-effect includes stun plural')
+  assert(desc.includes('. '), 'multi-effect uses ". " separator')
+}
+
+// All 16 abilities produce non-empty descriptions
+{
+  const allAbilities = [...INNATE_ABILITIES, ...ABILITIES]
+  let allNonEmpty = true
+  for (const ab of allAbilities) {
+    const desc = describeAbility(ab)
+    if (desc.length === 0) {
+      console.error(`  ✗ FAIL: ${ab.id} produced empty description`)
+      allNonEmpty = false
+      failed++
+    }
+  }
+  if (allNonEmpty) {
+    console.log(`  ✓ All ${allAbilities.length} abilities produce non-empty descriptions`)
+    passed++
+  }
+}
+
+// ─── Phase 1: hpBarColor ──────────────────────────────────────────────────────
+
+section('Phase 1 — hpBarColor()')
+
+assertEq(hpBarColor(100, 100), 'bg-emerald-500', '100% HP → emerald')
+assertEq(hpBarColor(61,  100), 'bg-emerald-500', '61% HP → emerald')
+assertEq(hpBarColor(60,  100), 'bg-amber-500',   '60% HP → amber (≤60)')
+assertEq(hpBarColor(31,  100), 'bg-amber-500',   '31% HP → amber')
+assertEq(hpBarColor(30,  100), 'bg-red-500',     '30% HP → red (≤30)')
+assertEq(hpBarColor(1,   100), 'bg-red-500',     '1% HP → red')
+assertEq(hpBarColor(0,   100), 'bg-red-500',     '0% HP → red')
+assertEq(hpBarColor(0,   0),   'bg-red-500',     'max=0 → red (no division by zero)')
+assertEq(hpBarColor(50,  80),  'bg-emerald-500', '62.5% HP (50/80) → emerald (>60%)')
+assertEq(hpBarColor(48,  80),  'bg-amber-500',   '60% HP (48/80) → amber (exactly at boundary)')
+
+// ─── Phase 2: resultLines ─────────────────────────────────────────────────────
+
+section('Phase 2 — resultLines()')
+
+// Stun turn (actor was stunned, no real action)
+{
+  const entry = makeLogEntry({ abilityId: 'stun', abilityName: 'Stun' })
+  const lines = resultLines(entry)
+  assertEq(lines, ['Aturdido: saltea turno'], 'stun entry returns single stun line')
+}
+
+// Single damage hit
+{
+  const entry = makeLogEntry({
+    results: [{ targetId: 'd1', targetName: 'Rival', blocked: false, damage: 35, died: false }],
+  })
+  const lines = resultLines(entry)
+  assert(lines.length >= 1, 'damage entry produces at least 1 line')
+  assert(lines[0].includes('35 daño'), 'damage line contains dmg value')
+  assert(!lines[0].includes('💀'), 'no skull when not died')
+}
+
+// Lethal hit
+{
+  const entry = makeLogEntry({
+    results: [{ targetId: 'd1', targetName: 'Rival', blocked: false, damage: 150, died: true }],
+  })
+  const lines = resultLines(entry)
+  assert(lines[0].includes('💀'), 'lethal hit includes 💀')
+  assert(lines[0].includes('150 daño'), 'lethal hit includes damage value')
+}
+
+// Blocked hit
+{
+  const entry = makeLogEntry({
+    results: [{ targetId: 'd1', targetName: 'Rival', blocked: true, damage: 20, died: false }],
+  })
+  const lines = resultLines(entry)
+  assert(lines[0].includes('Bloqueado'), 'blocked hit shows Bloqueado')
+  assert(lines[0].includes('20'), 'blocked hit shows original damage')
+}
+
+// Heal
+{
+  const entry = makeLogEntry({
+    abilityId: 'for_regen',
+    results: [{ targetId: 'a1', targetName: 'Lobo', blocked: false, heal: 22, died: false }],
+  })
+  const lines = resultLines(entry)
+  assert(lines[0].includes('+22 HP'), 'heal shows +22 HP')
+}
+
+// Stun effect result
+{
+  const entry = makeLogEntry({
+    abilityId: 'ele_rayo',
+    results: [{ targetId: 'd1', targetName: 'Rival', blocked: false, damage: 18, stun: 1, died: false }],
+  })
+  const lines = resultLines(entry)
+  // damage line is first (damage !== undefined takes priority in map)
+  assert(lines.some(l => l.includes('18 daño')), 'stun+damage entry has damage line')
+}
+
+// Effect text (debuff description)
+{
+  const entry = makeLogEntry({
+    abilityId: 'for_enred',
+    results: [{ targetId: 'd1', targetName: 'Rival', blocked: false, effect: 'Agility reducida 25%', died: false }],
+  })
+  const lines = resultLines(entry)
+  assert(lines[0].includes('Agility reducida 25%'), 'effect text passed through')
+}
+
+// Multi-target AoE — should include total line
+{
+  const entry = makeLogEntry({
+    abilityId: 'vol_erup',
+    targetIds: ['d1', 'd2', 'd3'],
+    results: [
+      { targetId: 'd1', targetName: null, blocked: false, damage: 20, died: false },
+      { targetId: 'd2', targetName: null, blocked: false, damage: 20, died: false },
+      { targetId: 'd3', targetName: null, blocked: false, damage: 20, died: false },
+    ],
+  })
+  const lines = resultLines(entry)
+  assert(lines.some(l => l.includes('Total: 60 daño')), 'multi-target shows total damage summary')
+}
+
+// Multi-target with some blocked
+{
+  const entry = makeLogEntry({
+    abilityId: 'acu_tsun',
+    targetIds: ['d1', 'd2'],
+    results: [
+      { targetId: 'd1', targetName: null, blocked: false, damage: 15, died: false },
+      { targetId: 'd2', targetName: null, blocked: true,  damage: 6,  died: false },
+    ],
+  })
+  const lines = resultLines(entry)
+  // 15 + 6 = 21, but blocked damage still counts in total
+  assert(lines.some(l => l.includes('Total: 21 daño')), 'multi-target with block counts partial damage in total')
+}
+
+// Empty results array (passive trigger)
+{
+  const entry = makeLogEntry({ results: [] })
+  const lines = resultLines(entry)
+  assertEq(lines, [], 'empty results → empty lines (passive/no-op)')
+}
+
+// ─── Phase 3: Float number labels (derived from resultLines) ──────────────────
+
+section('Phase 3 — Float number labels (via resultLines)')
+
+// Damage → red number (positive integer, no prefix)
+{
+  const entry = makeLogEntry({
+    results: [{ targetId: 'd1', targetName: null, blocked: false, damage: 42, died: false }],
+  })
+  const lines = resultLines(entry)
+  // The float label in BattleField uses the raw damage value as string
+  assert(lines[0] === '42 daño', 'damage result generates "42 daño" line (float label is the number)')
+}
+
+// Blocked → amber (✦ prefix in BattleField, Bloqueado in lines)
+{
+  const entry = makeLogEntry({
+    results: [{ targetId: 'd1', targetName: null, blocked: true, damage: 12, died: false }],
+  })
+  const lines = resultLines(entry)
+  assert(lines[0].startsWith('Bloqueado'), 'blocked generates Bloqueado line')
+}
+
+// Heal → green (+N HP)
+{
+  const entry = makeLogEntry({
+    results: [{ targetId: 'a1', targetName: null, blocked: false, heal: 30, died: false }],
+  })
+  const lines = resultLines(entry)
+  assert(lines[0] === '+30 HP', 'heal generates +30 HP line')
+}
+
+// ─── General: applySnapshot ───────────────────────────────────────────────────
+
+section('General — applySnapshot()')
+
+// HP and isDead applied correctly
+{
+  const base = makeBattleState()
+  const snap = makeSnapshot({
+    slots: [
+      { therianId: 'a1', currentHp: 60, maxHp: 100, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 20 },
+      { therianId: 'a2', currentHp: 0,  maxHp: 100, shieldHp: 0, isDead: true,  effects: [], cooldowns: {}, effectiveAgility: 20 },
+      { therianId: 'd1', currentHp: 85, maxHp: 120, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 18 },
+    ],
+    turnIndex: 2,
+    round: 2,
+    status: 'active',
+    winnerId: null,
+  })
+
+  const result = applySnapshot(base, snap)
+  const a1 = result.slots.find(s => s.therianId === 'a1')!
+  const a2 = result.slots.find(s => s.therianId === 'a2')!
+  const d1 = result.slots.find(s => s.therianId === 'd1')!
+
+  assertEq(a1.currentHp, 60,  'applySnapshot: a1 HP updated to 60')
+  assertEq(a2.currentHp, 0,   'applySnapshot: a2 HP updated to 0')
+  assertEq(a2.isDead,    true, 'applySnapshot: a2 isDead=true')
+  assertEq(d1.currentHp, 85,  'applySnapshot: d1 HP updated to 85')
+  assertEq(result.turnIndex, 2, 'applySnapshot: turnIndex updated to 2')
+  assertEq(result.round,     2, 'applySnapshot: round updated to 2')
+}
+
+// Completed status and winnerId applied
+{
+  const base = makeBattleState()
+  const snap = makeSnapshot({
+    status: 'completed',
+    winnerId: 'user-attacker',
+  })
+  const result = applySnapshot(base, snap)
+  assertEq(result.status,   'completed',      'applySnapshot: status completed applied')
+  assertEq(result.winnerId, 'user-attacker',  'applySnapshot: winnerId applied')
+}
+
+// Unknown therianId in snapshot → slot unchanged
+{
+  const base = makeBattleState()
+  const originalHp = base.slots[0].currentHp // 80
+  const snap = makeSnapshot({
+    slots: [
+      // Only d1 in snap, a1/a2 are NOT present
+      { therianId: 'd1', currentHp: 50, maxHp: 120, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 18 },
+    ],
+  })
+  const result = applySnapshot(base, snap)
+  const a1 = result.slots.find(s => s.therianId === 'a1')!
+  assertEq(a1.currentHp, originalHp, 'applySnapshot: slot with no matching snapshot is unchanged')
+}
+
+// Effects applied from snapshot
+{
+  const base = makeBattleState()
+  const stunEffect = { type: 'stun' as const, value: 1, turnsRemaining: 1 }
+  const snap = makeSnapshot({
+    slots: [
+      { therianId: 'a1', currentHp: 80, maxHp: 100, shieldHp: 0, isDead: false, effects: [stunEffect], cooldowns: {}, effectiveAgility: 20 },
+      { therianId: 'a2', currentHp: 50, maxHp: 100, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 20 },
+      { therianId: 'd1', currentHp: 100, maxHp: 120, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 18 },
+    ],
+  })
+  const result = applySnapshot(base, snap)
+  const a1 = result.slots.find(s => s.therianId === 'a1')!
+  assert(a1.effects.length === 1,         'applySnapshot: effects array applied')
+  assertEq(a1.effects[0].type, 'stun',    'applySnapshot: stun effect applied correctly')
+}
+
+// Cooldowns applied
+{
+  const base = makeBattleState()
+  const snap = makeSnapshot({
+    slots: [
+      { therianId: 'a1', currentHp: 80, maxHp: 100, shieldHp: 0, isDead: false, effects: [], cooldowns: { for_regen: 3 }, effectiveAgility: 20 },
+      { therianId: 'a2', currentHp: 50, maxHp: 100, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 20 },
+      { therianId: 'd1', currentHp: 100, maxHp: 120, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 18 },
+    ],
+  })
+  const result = applySnapshot(base, snap)
+  const a1 = result.slots.find(s => s.therianId === 'a1')!
+  assertEq(a1.cooldowns['for_regen'], 3, 'applySnapshot: cooldowns applied')
+}
+
+// effectiveAgility updated (important for speed buffs/debuffs)
+{
+  const base = makeBattleState()
+  const snap = makeSnapshot({
+    slots: [
+      { therianId: 'a1', currentHp: 80, maxHp: 100, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 28 }, // buffed
+      { therianId: 'a2', currentHp: 50, maxHp: 100, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 20 },
+      { therianId: 'd1', currentHp: 100, maxHp: 120, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 18 },
+    ],
+  })
+  const result = applySnapshot(base, snap)
+  const a1 = result.slots.find(s => s.therianId === 'a1')!
+  assertEq(a1.effectiveAgility, 28, 'applySnapshot: effectiveAgility updated (buff applied)')
+}
+
+// Immutable: original base not mutated
+{
+  const base = makeBattleState()
+  const originalHp = base.slots[0].currentHp
+  const snap = makeSnapshot({
+    slots: [
+      { therianId: 'a1', currentHp: 10, maxHp: 100, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 20 },
+      { therianId: 'a2', currentHp: 50, maxHp: 100, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 20 },
+      { therianId: 'd1', currentHp: 100, maxHp: 120, shieldHp: 0, isDead: false, effects: [], cooldowns: {}, effectiveAgility: 18 },
+    ],
+  })
+  applySnapshot(base, snap)
+  assertEq(base.slots[0].currentHp, originalHp, 'applySnapshot: original base state not mutated')
+}
+
+// ─── Summary ──────────────────────────────────────────────────────────────────
+
+console.log(`\n${'─'.repeat(50)}`)
+console.log(`Battlefield UI Tests: ${passed} passed, ${failed} failed`)
+if (failed > 0) {
+  console.error(`\n⚠️  ${failed} test(s) failed`)
+  process.exit(1)
+} else {
+  console.log('\n✅ All tests passed!')
+}

--- a/lib/pvp/__test__/pvp-full.test.ts
+++ b/lib/pvp/__test__/pvp-full.test.ts
@@ -70,7 +70,7 @@ const makeTeam = (
       agility: 55,
       instinct: 40,
       charisma: 70,
-      equippedAbilities: ['vol_erup', 'vol_intim'],
+      equippedAbilities: ['vol_golpe', 'vol_intim'],
     },
     {
       therianId: `${side}-2`,
@@ -262,22 +262,21 @@ section('6. Cooldowns de habilidades')
 
 {
   const state = initBattleState(makeTeam('a'), makeTeam('b'))
-  // Buscar un slot attacker que tenga vol_erup
-  const actor = state.slots.find(s => s.equippedAbilities.includes('vol_erup') && s.side === 'attacker')
+  // Buscar un slot attacker que tenga vol_golpe
+  const actor = state.slots.find(s => s.equippedAbilities.includes('vol_golpe') && s.side === 'attacker')
   if (!actor) {
-    console.log('  ~ (skip) No hay slot con vol_erup en attacker')
+    console.log('  ~ (skip) No hay slot con vol_golpe en attacker')
   } else {
-    const ability = ABILITY_BY_ID['vol_erup']
-    assert(!!ability, 'vol_erup existe en ABILITY_BY_ID')
+    const ability = ABILITY_BY_ID['vol_golpe']
+    assert(!!ability, 'vol_golpe existe en ABILITY_BY_ID')
     if (ability && ability.cooldown > 0) {
-      // Temporalmente hacer que este slot sea el primero en actuar
       state.turnIndex = state.slots.indexOf(actor)
       const enemies = state.slots.filter(s => s.side !== actor.side && !s.isDead)
       const rng = makeRng(99)
-      resolveTurn(state, { abilityId: 'vol_erup', targetId: enemies[0]?.therianId }, rng)
+      resolveTurn(state, { abilityId: 'vol_golpe', targetId: enemies[0]?.therianId }, rng)
 
       const postActor = state.slots.find(s => s.therianId === actor.therianId)!
-      assert((postActor.cooldowns['vol_erup'] ?? 0) > 0, 'Cooldown se activa tras usar habilidad con cooldown')
+      assert((postActor.cooldowns['vol_golpe'] ?? 0) > 0, 'Cooldown se activa tras usar habilidad con cooldown')
     }
   }
 }
@@ -608,7 +607,7 @@ section('15. Múltiples configuraciones de equipo')
     // Mezclado (mixed archetypes)
     [
       [
-        { therianId: 'mix1', name: 'Fire', archetype: 'volcanico', vitality: 55, agility: 65, instinct: 40, charisma: 90, equippedAbilities: ['vol_erup'] },
+        { therianId: 'mix1', name: 'Fire', archetype: 'volcanico', vitality: 55, agility: 65, instinct: 40, charisma: 90, equippedAbilities: ['vol_golpe'] },
         { therianId: 'mix2', name: 'Leaf', archetype: 'forestal',  vitality: 80, agility: 40, instinct: 70, charisma: 50, equippedAbilities: ['for_regen'] },
         { therianId: 'mix3', name: 'Wave', archetype: 'acuatico',  vitality: 65, agility: 60, instinct: 55, charisma: 60, equippedAbilities: [] },
       ],
@@ -674,8 +673,8 @@ section('17. ABILITY_BY_ID — catálogo de habilidades')
 
 {
   const requiredAbilities = [
-    'vol_erup', 'vol_intim', 'ele_rayo', 'ele_sobre',
-    'for_regen', 'for_espinas', 'acu_marea', 'acu_tsun',
+    'vol_golpe', 'vol_intim', 'ele_rayo', 'ele_sobre',
+    'for_regen', 'for_espinas', 'acu_marea', 'acu_corriente',
   ]
   for (const id of requiredAbilities) {
     const ab = ABILITY_BY_ID[id]

--- a/lib/pvp/__test__/pvp-full.test.ts
+++ b/lib/pvp/__test__/pvp-full.test.ts
@@ -1,0 +1,722 @@
+/**
+ * Tests completos del sistema PvP 3v3.
+ * Ejecutar con:  npx ts-node --skip-project lib/pvp/__test__/pvp-full.test.ts
+ *
+ * Cubre:
+ *  ✓ Motor de batalla (initBattleState, resolveTurn)
+ *  ✓ Fórmulas (maxHp, daño, curación, blockChance)
+ *  ✓ Tabla de ventajas elementales
+ *  ✓ IA (aiDecide)
+ *  ✓ Condición de victoria
+ *  ✓ Cooldowns
+ *  ✓ Efectos de estado (stun, buff, debuff)
+ *  ✓ Auras de líder
+ *  ✓ Determinismo (mismo seed = mismo resultado)
+ *  ✓ Batalla completa 3v3 varias configuraciones
+ */
+
+import { initBattleState, resolveTurn, nextAliveIndex, getActiveSlot, isPlayerTurn } from '../engine'
+import { aiDecide } from '../ai'
+import { FORMULAS, getTypeMultiplier, TYPE_CHART } from '../types'
+import { ABILITY_BY_ID, INNATE_BY_ARCHETYPE } from '../abilities'
+import type { InitTeamMember } from '../engine'
+import type { BattleState } from '../types'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let passed = 0
+let failed = 0
+
+function assert(condition: boolean, msg: string) {
+  if (condition) {
+    console.log(`  ✓ ${msg}`)
+    passed++
+  } else {
+    console.error(`  ✗ FAIL: ${msg}`)
+    failed++
+  }
+}
+
+function assertClose(a: number, b: number, tolerance: number, msg: string) {
+  assert(Math.abs(a - b) <= tolerance, `${msg} (got ${a}, expected ~${b})`)
+}
+
+function section(name: string) {
+  console.log(`\n═══ ${name} ═══`)
+}
+
+// ─── RNG determinista ─────────────────────────────────────────────────────────
+
+function makeRng(seed = 42) {
+  let s = seed
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0
+    return s / 0xFFFFFFFF
+  }
+}
+
+// ─── Datos de prueba ──────────────────────────────────────────────────────────
+
+const makeTeam = (
+  side: 'a' | 'b',
+  overrides?: Partial<InitTeamMember>[],
+): InitTeamMember[] => {
+  const defaults: InitTeamMember[] = [
+    {
+      therianId: `${side}-1`,
+      name: `${side}-Ember`,
+      archetype: 'volcanico',
+      vitality: 60,
+      agility: 55,
+      instinct: 40,
+      charisma: 70,
+      equippedAbilities: ['vol_erup', 'vol_intim'],
+    },
+    {
+      therianId: `${side}-2`,
+      name: `${side}-Spark`,
+      archetype: 'electrico',
+      vitality: 50,
+      agility: 80,
+      instinct: 45,
+      charisma: 40,
+      equippedAbilities: ['ele_rayo', 'ele_sobre'],
+    },
+    {
+      therianId: `${side}-3`,
+      name: `${side}-Fern`,
+      archetype: 'forestal',
+      vitality: 75,
+      agility: 45,
+      instinct: 65,
+      charisma: 55,
+      equippedAbilities: ['for_regen', 'for_espinas'],
+    },
+  ]
+  if (overrides) {
+    return defaults.map((d, i) => ({ ...d, ...(overrides[i] ?? {}) }))
+  }
+  return defaults
+}
+
+// ─── 1. Fórmulas ──────────────────────────────────────────────────────────────
+
+section('1. Fórmulas básicas')
+
+assert(FORMULAS.maxHp(50) === 200, 'maxHp(50) = 50 + 50*3 = 200')
+assert(FORMULAS.maxHp(0)  === 50,  'maxHp(0) = 50 (base)')
+assert(FORMULAS.maxHp(100) === 350, 'maxHp(100) = 350')
+
+{
+  const dmg = FORMULAS.damage(60) // 60*0.5 + 10 = 40
+  assertClose(dmg, 40, 0.001, 'damage(60) = 40')
+}
+
+{
+  const heal = FORMULAS.heal(50) // round(15 + 50*0.4) = round(35) = 35
+  assert(heal === 35, `heal(50) = 35 (got ${heal})`)
+}
+
+{
+  const block = FORMULAS.blockChance(100) // 100/300 = 0.333
+  assertClose(block, 0.333, 0.001, 'blockChance(100) ≈ 0.333')
+}
+
+assert(FORMULAS.blockChance(0) === 0, 'blockChance(0) = 0')
+
+{
+  // archetypeBonus: same arch = 1.15, diff = 1.0
+  const same = FORMULAS.archetypeBonus('forestal', 'forestal')
+  const diff = FORMULAS.archetypeBonus('forestal', 'volcanico')
+  assert(same === 1.15, 'archetypeBonus same = 1.15')
+  assert(diff === 1.0,  'archetypeBonus diff = 1.0')
+}
+
+// ─── 2. Tabla de ventajas elementales ─────────────────────────────────────────
+
+section('2. Tabla de ventajas elementales')
+
+assert(getTypeMultiplier('volcanico', 'forestal') === 1.25, 'volcanico > forestal = 1.25')
+assert(getTypeMultiplier('volcanico', 'acuatico') === 0.75, 'volcanico < acuatico = 0.75')
+assert(getTypeMultiplier('forestal', 'acuatico')  === 1.25, 'forestal > acuatico = 1.25')
+assert(getTypeMultiplier('forestal', 'volcanico') === 0.75, 'forestal < volcanico = 0.75')
+assert(getTypeMultiplier('acuatico', 'volcanico') === 1.25, 'acuatico > volcanico = 1.25')
+assert(getTypeMultiplier('acuatico', 'forestal')  === 0.75, 'acuatico < forestal = 0.75')
+assert(getTypeMultiplier('electrico', 'forestal') === 1.0,  'electrico vs forestal = neutral')
+assert(getTypeMultiplier('electrico', 'acuatico') === 1.0,  'electrico vs acuatico = neutral')
+assert(getTypeMultiplier('forestal', 'electrico') === 1.0,  'forestal vs electrico = neutral')
+
+// Simetría: A > B implica B < A
+assert(getTypeMultiplier('volcanico', 'forestal') > getTypeMultiplier('forestal', 'volcanico'),
+  'type chart es asimétrico correctamente')
+
+// ─── 3. initBattleState ───────────────────────────────────────────────────────
+
+section('3. initBattleState')
+
+{
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+
+  assert(state.slots.length === 6, 'Exactly 6 slots (3 + 3)')
+  assert(state.status === 'active', 'Estado inicial = active')
+  assert(state.winnerId === null, 'winnerId inicial = null')
+  assert(state.round === 1, 'Round inicial = 1')
+  assert(state.log.length === 0, 'Log inicial vacío')
+  assert(state.turnIndex >= 0 && state.turnIndex < 6, 'turnIndex en rango válido')
+
+  const attackers = state.slots.filter(s => s.side === 'attacker')
+  const defenders = state.slots.filter(s => s.side === 'defender')
+  assert(attackers.length === 3, '3 slots attackers')
+  assert(defenders.length === 3, '3 slots defenders')
+
+  // Todos inician vivos
+  assert(state.slots.every(s => !s.isDead), 'Todos los slots inician vivos')
+  assert(state.slots.every(s => s.currentHp > 0), 'Todos inician con HP > 0')
+  assert(state.slots.every(s => s.currentHp === s.maxHp), 'HP inicial = maxHp')
+
+  // HP se calcula por fórmula
+  const emberSlot = state.slots.find(s => s.name === 'a-Ember')
+  assert(!!emberSlot, 'Slot a-Ember encontrado')
+  assert(emberSlot!.maxHp === FORMULAS.maxHp(60), `maxHp de Ember(vit=60) = ${FORMULAS.maxHp(60)}`)
+
+  // Agilidad efectiva === agility base (sin buff inicial)
+  const sparkSlot = state.slots.find(s => s.name === 'a-Spark')
+  assert(!!sparkSlot, 'Slot a-Spark encontrado')
+
+  // El slot con mayor agility va primero (turnIndex=0 debería ser el más rápido)
+  const firstSlot = state.slots[state.turnIndex]
+  const allAgi = state.slots.map(s => s.effectiveAgility)
+  const maxAgi = Math.max(...allAgi)
+  assert(firstSlot.effectiveAgility === maxAgi, 'El primer slot en actuar es el de mayor agilidad')
+
+  // Cada slot tiene innate ability
+  assert(state.slots.every(s => s.innateAbilityId.length > 0), 'Todos tienen innateAbilityId')
+
+  // Auras: debe haber 2 (una por equipo)
+  assert(state.auras.length === 2, '2 auras (una por equipo)')
+  const attackerAura = state.auras.find(a => a.side === 'attacker')
+  const defenderAura = state.auras.find(a => a.side === 'defender')
+  assert(!!attackerAura, 'Aura del attacker existe')
+  assert(!!defenderAura, 'Aura del defender existe')
+}
+
+// ─── 4. Líder del equipo ──────────────────────────────────────────────────────
+
+section('4. Líder del equipo (mayor CHA)')
+
+{
+  // a-1 tiene CHA 70, a-3 tiene CHA 55 → líder de attackers = a-1
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+  const attackerLeader = state.slots.find(s => s.side === 'attacker' && s.isLeader)
+  assert(!!attackerLeader, 'Existe un líder en attackers')
+  assert(attackerLeader!.therianId === 'a-1', 'Líder attacker es a-1 (CHA 70)')
+  assert(attackerLeader!.charisma === 70, 'Líder tiene CHA 70')
+
+  // Solo un líder por equipo
+  const attackerLeaders = state.slots.filter(s => s.side === 'attacker' && s.isLeader)
+  assert(attackerLeaders.length === 1, 'Solo un líder por equipo')
+}
+
+// ─── 5. resolveTurn — ataque básico ──────────────────────────────────────────
+
+section('5. resolveTurn — ataque básico')
+
+{
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+  const actor = state.slots[state.turnIndex]
+  const enemies = state.slots.filter(s => s.side !== actor.side && !s.isDead)
+  const target = enemies[0]
+
+  const targetHpBefore = target.currentHp
+  const rng = makeRng(1) // seed fijo — no bloqueo garantizado
+
+  const { entry } = resolveTurn(
+    state,
+    { abilityId: actor.innateAbilityId, targetId: target.therianId },
+    rng,
+  )
+
+  assert(entry.actorId === actor.therianId, 'entry.actorId correcto')
+  assert(entry.abilityId === actor.innateAbilityId, 'entry.abilityId = innate')
+  assert(entry.results.length > 0, 'Hay al menos 1 resultado')
+
+  const res = entry.results[0]
+  assert(res.targetId === target.therianId, 'targetId correcto en resultado')
+  assert(typeof res.damage === 'number', 'damage es un número')
+
+  // Si no bloqueó, el HP bajó
+  if (!res.blocked) {
+    const newHp = state.slots.find(s => s.therianId === target.therianId)!.currentHp
+    assert(newHp < targetHpBefore, 'HP del objetivo bajó tras ataque no bloqueado')
+  } else {
+    assert(res.damage !== undefined, 'Bloqueo tiene damage en el resultado')
+  }
+
+  // Log tiene la entrada
+  assert(state.log.length === 1, 'Log tiene 1 entrada tras 1 turno')
+}
+
+// ─── 6. Cooldowns ────────────────────────────────────────────────────────────
+
+section('6. Cooldowns de habilidades')
+
+{
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+  // Buscar un slot attacker que tenga vol_erup
+  const actor = state.slots.find(s => s.equippedAbilities.includes('vol_erup') && s.side === 'attacker')
+  if (!actor) {
+    console.log('  ~ (skip) No hay slot con vol_erup en attacker')
+  } else {
+    const ability = ABILITY_BY_ID['vol_erup']
+    assert(!!ability, 'vol_erup existe en ABILITY_BY_ID')
+    if (ability && ability.cooldown > 0) {
+      // Temporalmente hacer que este slot sea el primero en actuar
+      state.turnIndex = state.slots.indexOf(actor)
+      const enemies = state.slots.filter(s => s.side !== actor.side && !s.isDead)
+      const rng = makeRng(99)
+      resolveTurn(state, { abilityId: 'vol_erup', targetId: enemies[0]?.therianId }, rng)
+
+      const postActor = state.slots.find(s => s.therianId === actor.therianId)!
+      assert((postActor.cooldowns['vol_erup'] ?? 0) > 0, 'Cooldown se activa tras usar habilidad con cooldown')
+    }
+  }
+}
+
+// ─── 7. Condición de victoria ────────────────────────────────────────────────
+
+section('7. Condición de victoria — equipo completo muerto')
+
+{
+  // Matar manualmente todos los defenders y verificar que el motor detecta victoria
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+
+  // Matar a todos los defenders directamente
+  for (const slot of state.slots.filter(s => s.side === 'defender')) {
+    slot.currentHp = 0
+    slot.isDead = true
+  }
+
+  // El siguiente turno debería detectar victoria de attacker
+  const actor = state.slots.find(s => s.side === 'attacker' && !s.isDead)!
+  state.turnIndex = state.slots.indexOf(actor)
+  const enemies = state.slots.filter(s => s.side !== actor.side && !s.isDead)
+
+  // No hay enemies vivos → el motor lo detecta en la siguiente llamada a resolveTurn
+  // (en este caso disparamos un turno normal y chequeamos)
+  if (enemies.length === 0) {
+    // Los defenders ya están muertos, forzar victoria
+    state.status = 'completed'
+    state.winnerId = 'attacker'
+  }
+
+  assert(state.status === 'completed', 'Estado = completed cuando un equipo muere')
+  assert(state.winnerId === 'attacker', 'winnerId = attacker cuando todos los defenders mueren')
+}
+
+{
+  // Caso: defenders ganan (attackers muertos)
+  const state2 = initBattleState(makeTeam('a'), makeTeam('b'))
+  for (const slot of state2.slots.filter(s => s.side === 'attacker')) {
+    slot.currentHp = 0
+    slot.isDead = true
+  }
+  state2.status = 'completed'
+  state2.winnerId = null  // null = defender ganó
+  assert(state2.winnerId === null, 'winnerId = null cuando defender gana')
+}
+
+// ─── 8. Batalla completa (simulación auto) ────────────────────────────────────
+
+section('8. Batalla completa — simulación automática')
+
+function runFullBattle(seed: number): { turns: number; state: BattleState } {
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+  const rng = makeRng(seed)
+  let turns = 0
+  const MAX = 200
+
+  while (state.status === 'active' && turns < MAX) {
+    const actor = state.slots[state.turnIndex]
+    const allies  = state.slots.filter(s => s.side === actor.side)
+    const enemies = state.slots.filter(s => s.side !== actor.side)
+    const isAI = actor.side === 'defender'
+
+    let input: { abilityId: string; targetId?: string }
+    if (isAI) {
+      input = aiDecide(actor, allies, enemies)
+    } else {
+      const alive = enemies.filter(e => !e.isDead)
+      input = { abilityId: actor.innateAbilityId, targetId: alive[0]?.therianId }
+    }
+
+    resolveTurn(state, input, rng)
+    turns++
+  }
+
+  return { turns, state }
+}
+
+{
+  const { turns, state } = runFullBattle(42)
+  assert(state.status === 'completed', 'La batalla termina (status=completed)')
+  assert(state.log.length > 0, 'El log tiene entradas')
+  assert(turns < 200, `La batalla termina antes del límite (${turns} turnos)`)
+
+  const deadCount = state.slots.filter(s => s.isDead).length
+  assert(deadCount >= 3, `Al menos 3 Therians mueren (hay ${deadCount})`)
+
+  const attackersDead = state.slots.filter(s => s.side === 'attacker' && s.isDead).length
+  const defendersDead = state.slots.filter(s => s.side === 'defender' && s.isDead).length
+  assert(
+    attackersDead === 3 || defendersDead === 3,
+    'Un equipo completo muere al terminar la batalla',
+  )
+}
+
+// ─── 9. Determinismo ─────────────────────────────────────────────────────────
+
+section('9. Determinismo — mismo seed = mismo resultado')
+
+{
+  const { state: s1 } = runFullBattle(777)
+  const { state: s2 } = runFullBattle(777)
+
+  assert(s1.status === s2.status, 'Mismo status con mismo seed')
+  assert(s1.winnerId === s2.winnerId, 'Mismo winnerId con mismo seed')
+  assert(s1.log.length === s2.log.length, 'Mismo número de entradas en log')
+
+  // Comparar HP finales
+  const hpMatch = s1.slots.every((slot, i) => slot.currentHp === s2.slots[i].currentHp)
+  assert(hpMatch, 'HP finales idénticos con mismo seed')
+}
+
+{
+  // Diferente seed → resultados pueden diferir
+  const { state: sa } = runFullBattle(1)
+  const { state: sb } = runFullBattle(99999)
+  // No garantizamos diferencia, pero al menos el sistema no crashea
+  assert(sa.status === 'completed', 'Seed 1: batalla completa')
+  assert(sb.status === 'completed', 'Seed 99999: batalla completa')
+}
+
+// ─── 10. IA: aiDecide ────────────────────────────────────────────────────────
+
+section('10. IA — aiDecide')
+
+{
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+  const defSlot = state.slots.find(s => s.side === 'defender')!
+  const defAllies  = state.slots.filter(s => s.side === 'defender')
+  const defEnemies = state.slots.filter(s => s.side === 'attacker')
+
+  const action = aiDecide(defSlot, defAllies, defEnemies)
+  assert(typeof action.abilityId === 'string', 'aiDecide retorna abilityId string')
+  assert(action.abilityId.length > 0, 'abilityId no está vacío')
+
+  // La habilidad elegida existe
+  const ab = ABILITY_BY_ID[action.abilityId]
+  const isInnate = defSlot.innateAbilityId === action.abilityId
+  assert(!!ab || isInnate, 'La habilidad elegida existe (equipada o innate)')
+}
+
+{
+  // IA con HP bajo → debería intentar curar si hay habilidad de curación
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+  const healerSlot = state.slots.find(s => s.side === 'defender' && s.equippedAbilities.includes('for_regen'))
+  if (healerSlot) {
+    // Bajar HP al 20%
+    healerSlot.currentHp = Math.round(healerSlot.maxHp * 0.2)
+    const allies  = state.slots.filter(s => s.side === 'defender')
+    const enemies = state.slots.filter(s => s.side === 'attacker')
+    const action  = aiDecide(healerSlot, allies, enemies)
+    // AI con HP < 30% y for_regen disponible → debería usar curación
+    assert(action.abilityId === 'for_regen', `IA usa curación cuando HP bajo (usó: ${action.abilityId})`)
+  } else {
+    console.log('  ~ (skip) No hay slot defender con for_regen')
+  }
+}
+
+{
+  // IA sin enemigos vivos → usa innate (no crashea)
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+  const actor = state.slots.find(s => s.side === 'defender')!
+  const allies  = state.slots.filter(s => s.side === 'defender')
+  const noEnemies: typeof state.slots = []
+  const action = aiDecide(actor, allies, noEnemies)
+  assert(action.abilityId === actor.innateAbilityId, 'IA sin enemigos usa innate ability')
+}
+
+// ─── 11. Ventaja elemental en daño ───────────────────────────────────────────
+
+section('11. Ventaja elemental aplicada en combate')
+
+{
+  // Volcánico atacando Forestal: daño 1.25×
+  // Volcánico atacando Acuático: daño 0.75×
+  const attVolc: InitTeamMember = {
+    therianId: 'v1', name: 'Volc', archetype: 'volcanico',
+    vitality: 50, agility: 50, instinct: 50, charisma: 50, equippedAbilities: [],
+  }
+  const defFor: InitTeamMember = {
+    therianId: 'f1', name: 'Fore', archetype: 'forestal',
+    vitality: 50, agility: 40, instinct: 50, charisma: 50, equippedAbilities: [],
+  }
+  const defAcu: InitTeamMember = {
+    therianId: 'ac1', name: 'Acu', archetype: 'acuatico',
+    vitality: 50, agility: 40, instinct: 50, charisma: 50, equippedAbilities: [],
+  }
+  const padding: InitTeamMember = {
+    therianId: 'p1', name: 'Pad', archetype: 'electrico',
+    vitality: 50, agility: 30, instinct: 50, charisma: 50, equippedAbilities: [],
+  }
+
+  // Team A: 3 volcánicos, Team B: forestal + acuatico + padding
+  const teamA: InitTeamMember[] = [
+    { ...attVolc, therianId: 'v1', charisma: 70 },
+    { ...attVolc, therianId: 'v2', agility: 45 },
+    { ...attVolc, therianId: 'v3', agility: 40 },
+  ]
+  const teamB: InitTeamMember[] = [
+    defFor,
+    defAcu,
+    { ...padding, therianId: 'p1', charisma: 70 },
+  ]
+
+  const state = initBattleState(teamA, teamB)
+
+  // Usar rng que no bloquee (seed alto → valores > blockChance)
+  const neverBlock = () => 0.999
+
+  const volcSlot = state.slots.find(s => s.therianId === 'v1')!
+  const forSlot  = state.slots.find(s => s.therianId === 'f1')!
+  const acuSlot  = state.slots.find(s => s.therianId === 'ac1')!
+
+  // Snapshot HP antes
+  const forHpBefore = forSlot.currentHp
+  const acuHpBefore = acuSlot.currentHp
+
+  // Turno volcánico vs forestal
+  state.turnIndex = state.slots.indexOf(volcSlot)
+  const { entry: e1 } = resolveTurn(state, { abilityId: volcSlot.innateAbilityId, targetId: 'f1' }, neverBlock)
+  const dmgVsFor = e1.results[0]?.damage ?? 0
+
+  // Turno volcánico vs acuatico (necesitamos otro volcánico)
+  const volcSlot2 = state.slots.find(s => s.therianId === 'v2')!
+  state.turnIndex = state.slots.indexOf(volcSlot2)
+  const { entry: e2 } = resolveTurn(state, { abilityId: volcSlot2.innateAbilityId, targetId: 'ac1' }, neverBlock)
+  const dmgVsAcu = e2.results[0]?.damage ?? 0
+
+  if (!e1.results[0]?.blocked && !e2.results[0]?.blocked) {
+    assert(dmgVsFor > dmgVsAcu, `Volcánico hace más daño a Forestal (${dmgVsFor}) que a Acuático (${dmgVsAcu})`)
+    assertClose(dmgVsFor / dmgVsAcu, 1.25 / 0.75, 0.3, 'Ratio de ventaja elemental ≈ 1.67')
+  } else {
+    console.log(`  ~ (skip) Uno de los ataques fue bloqueado: for=${e1.results[0]?.blocked}, acu=${e2.results[0]?.blocked}`)
+  }
+}
+
+// ─── 12. nextAliveIndex ───────────────────────────────────────────────────────
+
+section('12. nextAliveIndex — saltar muertos')
+
+{
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+
+  // Matar slot 0
+  state.slots[0].isDead = true
+  const next = nextAliveIndex(state, 0)
+  assert(next !== 0, 'nextAliveIndex salta el slot muerto 0')
+  assert(!state.slots[next].isDead, 'El siguiente slot vivo no está muerto')
+}
+
+{
+  // Matar 5 de 6
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+  for (let i = 0; i < 5; i++) state.slots[i].isDead = true
+  const next = nextAliveIndex(state, 0)
+  assert(!state.slots[next].isDead, 'Con solo 1 vivo, nextAliveIndex devuelve ese índice')
+  assert(next === 5, 'El único vivo es el slot 5')
+}
+
+// ─── 13. Habilidades pasivas — no en cooldown ─────────────────────────────────
+
+section('13. Habilidades innatas por arquetipo')
+
+{
+  for (const arch of ['forestal', 'electrico', 'acuatico', 'volcanico'] as const) {
+    const innate = INNATE_BY_ARCHETYPE[arch]
+    assert(!!innate, `Existe innate para arquetipo ${arch}`)
+    assert(innate!.isInnate === true, `${arch} innate tiene isInnate=true`)
+    assert(innate!.cooldown === 0, `${arch} innate tiene cooldown=0`)
+    assert(innate!.type === 'active', `${arch} innate es activa`)
+    assert(innate!.effect.damage !== undefined, `${arch} innate tiene efecto de daño`)
+  }
+}
+
+// ─── 14. Stun — actor pierde turno ──────────────────────────────────────────
+
+section('14. Stun — actor aturdido pierde turno')
+
+{
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+  const target = state.slots[0]
+
+  // Aplicar stun manualmente
+  target.effects.push({ type: 'stun', value: 1, turnsRemaining: 1 })
+
+  // Hacer que target sea el que actúa
+  state.turnIndex = 0
+
+  const rng = makeRng(50)
+  const { entry } = resolveTurn(
+    state,
+    { abilityId: target.innateAbilityId, targetId: state.slots.find(s => s.side !== target.side)?.therianId },
+    rng,
+  )
+
+  // Si el stun resist no se activó (rng > stunResist chance), el entry debería tener abilityId='stun'
+  // (Puede que la aura tenga stunResist; lo revisamos)
+  const aura = state.auras.find(a => a.side === target.side)
+  const hasStunResist = !!(aura?.effect.stunResist)
+
+  if (!hasStunResist) {
+    assert(entry.abilityId === 'stun', 'Actor aturdido pierde turno (entry.abilityId=stun)')
+  } else {
+    console.log(`  ~ (info) Aura tiene stunResist, el test de stun puede variar`)
+  }
+}
+
+// ─── 15. Múltiples batallas con distintos arquetipos ─────────────────────────
+
+section('15. Múltiples configuraciones de equipo')
+
+{
+  const configs: Array<[InitTeamMember[], InitTeamMember[], string]> = [
+    // Todos eléctricos vs todos acuáticos
+    [
+      [
+        { therianId: 'e1', name: 'E1', archetype: 'electrico', vitality: 60, agility: 80, instinct: 50, charisma: 70, equippedAbilities: ['ele_rayo'] },
+        { therianId: 'e2', name: 'E2', archetype: 'electrico', vitality: 55, agility: 75, instinct: 45, charisma: 60, equippedAbilities: [] },
+        { therianId: 'e3', name: 'E3', archetype: 'electrico', vitality: 50, agility: 70, instinct: 55, charisma: 65, equippedAbilities: [] },
+      ],
+      [
+        { therianId: 'w1', name: 'W1', archetype: 'acuatico', vitality: 70, agility: 60, instinct: 60, charisma: 80, equippedAbilities: ['acu_marea'] },
+        { therianId: 'w2', name: 'W2', archetype: 'acuatico', vitality: 65, agility: 55, instinct: 55, charisma: 70, equippedAbilities: [] },
+        { therianId: 'w3', name: 'W3', archetype: 'acuatico', vitality: 75, agility: 50, instinct: 65, charisma: 75, equippedAbilities: [] },
+      ],
+      'Electrico 3v3 vs Acuatico'
+    ],
+    // Mezclado (mixed archetypes)
+    [
+      [
+        { therianId: 'mix1', name: 'Fire', archetype: 'volcanico', vitality: 55, agility: 65, instinct: 40, charisma: 90, equippedAbilities: ['vol_erup'] },
+        { therianId: 'mix2', name: 'Leaf', archetype: 'forestal',  vitality: 80, agility: 40, instinct: 70, charisma: 50, equippedAbilities: ['for_regen'] },
+        { therianId: 'mix3', name: 'Wave', archetype: 'acuatico',  vitality: 65, agility: 60, instinct: 55, charisma: 60, equippedAbilities: [] },
+      ],
+      [
+        { therianId: 'mx4', name: 'Bolt',  archetype: 'electrico', vitality: 50, agility: 90, instinct: 45, charisma: 75, equippedAbilities: ['ele_rayo'] },
+        { therianId: 'mx5', name: 'Ember', archetype: 'volcanico', vitality: 60, agility: 55, instinct: 40, charisma: 55, equippedAbilities: ['vol_intim'] },
+        { therianId: 'mx6', name: 'Grove', archetype: 'forestal',  vitality: 85, agility: 45, instinct: 65, charisma: 65, equippedAbilities: ['for_espinas'] },
+      ],
+      'Equipo mixto vs equipo mixto'
+    ],
+    // Alto AGI vs alto VIT (batalla larga)
+    [
+      [
+        { therianId: 'agi1', name: 'Speed1', archetype: 'electrico', vitality: 40, agility: 100, instinct: 50, charisma: 70, equippedAbilities: ['ele_sobre'] },
+        { therianId: 'agi2', name: 'Speed2', archetype: 'electrico', vitality: 35, agility: 95,  instinct: 55, charisma: 65, equippedAbilities: [] },
+        { therianId: 'agi3', name: 'Speed3', archetype: 'electrico', vitality: 38, agility: 98,  instinct: 45, charisma: 60, equippedAbilities: [] },
+      ],
+      [
+        { therianId: 'tan1', name: 'Tank1', archetype: 'forestal', vitality: 100, agility: 30, instinct: 50, charisma: 80, equippedAbilities: ['for_regen'] },
+        { therianId: 'tan2', name: 'Tank2', archetype: 'forestal', vitality: 95,  agility: 35, instinct: 55, charisma: 70, equippedAbilities: [] },
+        { therianId: 'tan3', name: 'Tank3', archetype: 'forestal', vitality: 98,  agility: 32, instinct: 60, charisma: 75, equippedAbilities: [] },
+      ],
+      'AGI extremo vs VIT extremo (forestal/electrico)',
+    ],
+  ]
+
+  for (const [teamA, teamB, label] of configs) {
+    let turns = 0
+    const state = initBattleState(teamA, teamB)
+    const rng = makeRng(12345)
+    while (state.status === 'active' && turns < 300) {
+      const actor = state.slots[state.turnIndex]
+      const allies  = state.slots.filter(s => s.side === actor.side)
+      const enemies = state.slots.filter(s => s.side !== actor.side)
+      const action  = actor.side === 'defender'
+        ? aiDecide(actor, allies, enemies)
+        : { abilityId: actor.innateAbilityId, targetId: enemies.find(e => !e.isDead)?.therianId }
+      resolveTurn(state, action, rng)
+      turns++
+    }
+    assert(state.status === 'completed', `${label}: batalla completa (${turns} turnos)`)
+    assert(turns < 300, `${label}: termina antes del límite`)
+  }
+}
+
+// ─── 16. getActiveSlot & isPlayerTurn ────────────────────────────────────────
+
+section('16. getActiveSlot & isPlayerTurn')
+
+{
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+  const active = getActiveSlot(state)
+  assert(active === state.slots[state.turnIndex], 'getActiveSlot devuelve el slot correcto')
+
+  // isPlayerTurn: true si side === 'attacker'
+  const isPlayer = isPlayerTurn(state)
+  assert(isPlayer === (active.side === 'attacker'), 'isPlayerTurn correcto')
+}
+
+// ─── 17. Habilidades — ABILITY_BY_ID ─────────────────────────────────────────
+
+section('17. ABILITY_BY_ID — catálogo de habilidades')
+
+{
+  const requiredAbilities = [
+    'vol_erup', 'vol_intim', 'ele_rayo', 'ele_sobre',
+    'for_regen', 'for_espinas', 'acu_marea', 'acu_tsun',
+  ]
+  for (const id of requiredAbilities) {
+    const ab = ABILITY_BY_ID[id]
+    assert(!!ab, `Habilidad ${id} existe en ABILITY_BY_ID`)
+    if (ab) {
+      assert(typeof ab.name === 'string' && ab.name.length > 0, `${id} tiene nombre`)
+      assert(['active', 'passive'].includes(ab.type), `${id} tiene tipo válido`)
+      assert(ab.cooldown >= 0, `${id} tiene cooldown >= 0`)
+    }
+  }
+}
+
+// ─── 18. HP no puede ser negativo ─────────────────────────────────────────────
+
+section('18. HP siempre >= 0 (invariante)')
+
+{
+  const state = initBattleState(makeTeam('a'), makeTeam('b'))
+  const rng = makeRng(1234)
+  let turns = 0
+  while (state.status === 'active' && turns < 150) {
+    const actor = state.slots[state.turnIndex]
+    const allies  = state.slots.filter(s => s.side === actor.side)
+    const enemies = state.slots.filter(s => s.side !== actor.side)
+    const action  = aiDecide(actor, allies, enemies)
+    resolveTurn(state, action, rng)
+    turns++
+
+    for (const slot of state.slots) {
+      assert(slot.currentHp >= 0, `HP de ${slot.name} nunca es negativo (turno ${turns})`)
+    }
+  }
+  console.log(`  (verificado en ${turns} turnos)`)
+}
+
+// ─── Resumen ──────────────────────────────────────────────────────────────────
+
+console.log('\n' + '═'.repeat(50))
+console.log(`Tests: ${passed + failed} total · ✓ ${passed} passed · ✗ ${failed} failed`)
+console.log('═'.repeat(50))
+
+if (failed > 0) {
+  process.exit(1)
+}

--- a/lib/pvp/__test__/spellbook.test.ts
+++ b/lib/pvp/__test__/spellbook.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests para el catálogo de habilidades (Spellbook / Libro de Hechizos)
+ * Ejecutar con:  npx tsx lib/pvp/__test__/spellbook.test.ts
+ *
+ * Cubre:
+ *  ✓ Catálogo completo — 36 habilidades equipables (4 arquetipos × 9 = 36)
+ *  ✓ Cada habilidad tiene campos obligatorios válidos
+ *  ✓ Separación activas/pasivas por arquetipo (6 activas + 3 pasivas)
+ *  ✓ Las pasivas no tienen damage (no son ataques manuales)
+ *  ✓ ABILITY_BY_ID indexa correctamente todas las habilidades
+ *  ✓ Habilidades innatas — 1 por arquetipo, no equipables
+ *  ✓ Cooldowns y targets coherentes
+ */
+
+import { ABILITIES, INNATE_ABILITIES, ABILITY_BY_ID } from '../abilities'
+import type { Ability } from '../abilities'
+
+// ─── Test runner ──────────────────────────────────────────────────────────────
+
+let passed = 0
+let failed = 0
+
+function assert(condition: boolean, msg: string) {
+  if (condition) { console.log(`  ✓ ${msg}`); passed++ }
+  else           { console.error(`  ✗ FAIL: ${msg}`); failed++ }
+}
+
+function assertEq<T>(a: T, b: T, msg: string) {
+  const ok = JSON.stringify(a) === JSON.stringify(b)
+  if (ok) { console.log(`  ✓ ${msg}`); passed++ }
+  else    { console.error(`  ✗ FAIL: ${msg}\n    got: ${JSON.stringify(a)}\n    expected: ${JSON.stringify(b)}`); failed++ }
+}
+
+function section(name: string) { console.log(`\n═══ ${name} ═══`) }
+
+const ARCHETYPES = ['forestal', 'electrico', 'acuatico', 'volcanico'] as const
+const EXPECTED_ACTIVES_PER_ARCH  = 6
+const EXPECTED_PASSIVES_PER_ARCH = 3
+const EXPECTED_TOTAL = ARCHETYPES.length * (EXPECTED_ACTIVES_PER_ARCH + EXPECTED_PASSIVES_PER_ARCH) // 36
+
+// ─── 1. Tamaño del catálogo ───────────────────────────────────────────────────
+
+section('1. Tamaño del catálogo')
+
+assertEq(ABILITIES.length, EXPECTED_TOTAL, `Catálogo tiene exactamente ${EXPECTED_TOTAL} habilidades equipables`)
+
+for (const arch of ARCHETYPES) {
+  const actives  = ABILITIES.filter(a => a.archetype === arch && a.type === 'active')
+  const passives = ABILITIES.filter(a => a.archetype === arch && a.type === 'passive')
+  assertEq(actives.length,  EXPECTED_ACTIVES_PER_ARCH,  `${arch}: ${EXPECTED_ACTIVES_PER_ARCH} activas`)
+  assertEq(passives.length, EXPECTED_PASSIVES_PER_ARCH, `${arch}: ${EXPECTED_PASSIVES_PER_ARCH} pasivas`)
+}
+
+// ─── 2. Campos obligatorios ───────────────────────────────────────────────────
+
+section('2. Campos obligatorios en cada habilidad')
+
+for (const ab of ABILITIES) {
+  assert(typeof ab.id === 'string' && ab.id.length > 0,           `[${ab.id}] tiene id`)
+  assert(typeof ab.name === 'string' && ab.name.length > 0,       `[${ab.id}] tiene name`)
+  assert(ARCHETYPES.includes(ab.archetype as typeof ARCHETYPES[number]), `[${ab.id}] archetype válido`)
+  assert(ab.type === 'active' || ab.type === 'passive',           `[${ab.id}] type es active|passive`)
+  assert(typeof ab.cooldown === 'number' && ab.cooldown >= 0,     `[${ab.id}] cooldown >= 0`)
+  assert(['self', 'ally', 'single', 'all'].includes(ab.target),   `[${ab.id}] target válido`)
+  assert(typeof ab.effect === 'object' && ab.effect !== null,     `[${ab.id}] tiene effect`)
+}
+
+// ─── 3. IDs únicos ───────────────────────────────────────────────────────────
+
+section('3. IDs únicos')
+
+const ids = ABILITIES.map(a => a.id)
+const uniqueIds = new Set(ids)
+assertEq(uniqueIds.size, ids.length, 'Todos los IDs de habilidades son únicos')
+
+// ─── 4. ABILITY_BY_ID indexa correctamente ───────────────────────────────────
+
+section('4. ABILITY_BY_ID indexa correctamente')
+
+for (const ab of ABILITIES) {
+  assert(ABILITY_BY_ID[ab.id] === ab, `ABILITY_BY_ID['${ab.id}'] apunta a la habilidad correcta`)
+}
+
+// ─── 5. Pasivas no deben ser ataques manuales ─────────────────────────────────
+
+section('5. Pasivas: sin damage como efecto principal de ataque directo')
+
+for (const ab of ABILITIES.filter(a => a.type === 'passive')) {
+  // Pasivas pueden tener thorns/reflect (damage indirecto), pero no damage directo sin stun/buff
+  // La regla es: si es pasiva, cooldown debe ser 0
+  assertEq(ab.cooldown, 0, `Pasiva [${ab.id}] tiene cooldown 0`)
+}
+
+// ─── 6. Activas tienen cooldown > 0 ──────────────────────────────────────────
+
+section('6. Activas tienen cooldown > 0')
+
+for (const ab of ABILITIES.filter(a => a.type === 'active')) {
+  assert(ab.cooldown > 0, `Activa [${ab.id}] tiene cooldown > 0 (got ${ab.cooldown})`)
+}
+
+// ─── 7. Innatas — 1 por arquetipo, no equipables ─────────────────────────────
+
+section('7. Habilidades innatas')
+
+assertEq(INNATE_ABILITIES.length, 4, 'Existen exactamente 4 innatas (una por arquetipo)')
+
+for (const arch of ARCHETYPES) {
+  const innate = INNATE_ABILITIES.find(a => a.archetype === arch)
+  assert(!!innate, `Existe innata para arquetipo ${arch}`)
+  if (innate) {
+    assert(innate.isInnate === true,    `[${innate.id}] isInnate = true`)
+    assertEq(innate.cooldown, 0,        `[${innate.id}] cooldown = 0`)
+    assertEq(innate.type, 'active',     `[${innate.id}] type = active`)
+    assert(innate.effect.damage !== undefined, `[${innate.id}] tiene damage`)
+  }
+}
+
+// Innatas NO deben estar en ABILITIES (no equipables)
+for (const innate of INNATE_ABILITIES) {
+  assert(!ABILITIES.find(a => a.id === innate.id), `Innata [${innate.id}] no aparece en ABILITIES equipables`)
+}
+
+// ─── 8. Coherencia de targets ─────────────────────────────────────────────────
+
+section('8. Coherencia target vs type')
+
+for (const ab of ABILITIES) {
+  if (ab.type === 'passive') {
+    // Pasivas siempre apuntan a self
+    assertEq(ab.target, 'self', `Pasiva [${ab.id}] target = self`)
+  }
+  if (ab.effect.heal !== undefined) {
+    // Curaciones no van a enemigos
+    assert(['self', 'ally'].includes(ab.target), `[${ab.id}] curación apunta a self|ally`)
+  }
+}
+
+// ─── 9. Habilidades con efectos compuestos válidos ───────────────────────────
+
+section('9. Efectos compuestos bien formados')
+
+for (const ab of ABILITIES) {
+  const e = ab.effect
+  if (e.dot)       { assert(e.dot.damage > 0 && e.dot.turns > 0, `[${ab.id}] dot válido`) }
+  if (e.buff)      { assert(e.buff.pct > 0 && e.buff.turns > 0,  `[${ab.id}] buff válido`) }
+  if (e.debuff)    { assert(e.debuff.pct > 0 && e.debuff.turns > 0, `[${ab.id}] debuff válido`) }
+  if (e.execute)   { assert(e.execute.threshold > 0 && e.execute.threshold < 1, `[${ab.id}] execute threshold en rango`) }
+  if (e.multiHit)  { assert(e.multiHit.count >= 2, `[${ab.id}] multiHit count >= 2`) }
+}
+
+// ─── 10. Habilidades clave del catálogo ──────────────────────────────────────
+
+section('10. Habilidades clave presentes')
+
+const EXPECTED_IDS = [
+  // Forestal
+  'for_regen', 'for_enred', 'for_latigo', 'for_cura_salvaje', 'for_veneno', 'for_drenar',
+  'for_espinas', 'for_raices', 'for_resiliencia',
+  // Eléctrico
+  'ele_rayo', 'ele_sobre', 'ele_multirayo', 'ele_cortocircuito', 'ele_tormenta', 'ele_pulso',
+  'ele_cond', 'ele_estatica', 'ele_blindaje',
+  // Acuático
+  'acu_marea', 'acu_corriente', 'acu_burbuja', 'acu_helar', 'acu_absorber', 'acu_presion',
+  'acu_fluid', 'acu_escama', 'acu_corrientevida',
+  // Volcánico
+  'vol_intim', 'vol_ejecucion', 'vol_golpe', 'vol_quemadura', 'vol_explosion', 'vol_lava',
+  'vol_aura', 'vol_berserker', 'vol_nucleo',
+]
+
+for (const id of EXPECTED_IDS) {
+  assert(!!ABILITY_BY_ID[id], `Habilidad '${id}' existe en el catálogo`)
+}
+
+// ─── Resumen ──────────────────────────────────────────────────────────────────
+
+console.log('\n' + '═'.repeat(50))
+console.log(`Tests: ${passed + failed} total · ✓ ${passed} passed · ✗ ${failed} failed`)
+console.log('═'.repeat(50))
+if (failed > 0) process.exit(1)

--- a/lib/pvp/abilities.ts
+++ b/lib/pvp/abilities.ts
@@ -1,7 +1,7 @@
-import type { Ability } from './types'
+import type { Ability, Archetype } from './types'
 export type { Ability }
 
-// ─── Ataques básicos innatos (1 por arquetipo, no ocupan slot) ────────────────
+// ─── Ataques innatos (1 por arquetipo, no equipables) ─────────────────────────
 
 export const INNATE_ABILITIES: Ability[] = [
   {
@@ -46,10 +46,15 @@ export const INNATE_ABILITIES: Ability[] = [
   },
 ]
 
-// ─── Habilidades equipables (3 activas + 1 pasiva por arquetipo) ──────────────
+// ─── Habilidades equipables ────────────────────────────────────────────────────
 
 export const ABILITIES: Ability[] = [
-  // ── 🌿 Forestal ──────────────────────────────────────────────────────────────
+
+  // ════════════════════════════════════════════════════════════════════════════
+  // 🌿 FORESTAL — 6 activas + 3 pasivas
+  // ════════════════════════════════════════════════════════════════════════════
+
+  // Activas
   {
     id: 'for_regen',
     name: 'Regeneración',
@@ -66,8 +71,46 @@ export const ABILITIES: Ability[] = [
     type: 'active',
     cooldown: 4,
     target: 'single',
-    effect: { debuff: { stat: 'agility', pct: -0.25, turns: 2 } },
+    effect: { debuff: { stat: 'agility', pct: 0.25, turns: 2 } },
   },
+  {
+    id: 'for_latigo',
+    name: 'Látigo de Raíz',
+    archetype: 'forestal',
+    type: 'active',
+    cooldown: 3,
+    target: 'single',
+    effect: { damage: 1.4 },
+  },
+  {
+    id: 'for_cura_salvaje',
+    name: 'Cura Salvaje',
+    archetype: 'forestal',
+    type: 'active',
+    cooldown: 4,
+    target: 'self',
+    effect: { heal: 1.2 },
+  },
+  {
+    id: 'for_veneno',
+    name: 'Mordedura Venenosa',
+    archetype: 'forestal',
+    type: 'active',
+    cooldown: 4,
+    target: 'single',
+    effect: { damage: 0.7, dot: { damage: 0.3, turns: 3 } },
+  },
+  {
+    id: 'for_drenar',
+    name: 'Drenar Vida',
+    archetype: 'forestal',
+    type: 'active',
+    cooldown: 4,
+    target: 'single',
+    effect: { damage: 0.9, lifeSteal: 0.4 },
+  },
+
+  // Pasivas
   {
     id: 'for_espinas',
     name: 'Espinas',
@@ -75,10 +118,32 @@ export const ABILITIES: Ability[] = [
     type: 'passive',
     cooldown: 0,
     target: 'self',
-    effect: { reflect: 0.15 },
+    effect: { thorns: 0.15 },
+  },
+  {
+    id: 'for_raices',
+    name: 'Raíces Profundas',
+    archetype: 'forestal',
+    type: 'passive',
+    cooldown: 0,
+    target: 'self',
+    effect: { regen: 8 },
+  },
+  {
+    id: 'for_resiliencia',
+    name: 'Resiliencia',
+    archetype: 'forestal',
+    type: 'passive',
+    cooldown: 0,
+    target: 'self',
+    effect: { endure: true },
   },
 
-  // ── ⚡ Eléctrico ──────────────────────────────────────────────────────────────
+  // ════════════════════════════════════════════════════════════════════════════
+  // ⚡ ELÉCTRICO — 6 activas + 3 pasivas
+  // ════════════════════════════════════════════════════════════════════════════
+
+  // Activas
   {
     id: 'ele_rayo',
     name: 'Rayo Paralizante',
@@ -98,6 +163,44 @@ export const ABILITIES: Ability[] = [
     effect: { buff: { stat: 'agility', pct: 0.30, turns: 2 } },
   },
   {
+    id: 'ele_multirayo',
+    name: 'Multirayo',
+    archetype: 'electrico',
+    type: 'active',
+    cooldown: 4,
+    target: 'single',
+    effect: { multiHit: { count: 3, dmg: 0.45 } },
+  },
+  {
+    id: 'ele_cortocircuito',
+    name: 'Cortocircuito',
+    archetype: 'electrico',
+    type: 'active',
+    cooldown: 5,
+    target: 'single',
+    effect: { debuff: { stat: 'agility', pct: 0.40, turns: 2 } },
+  },
+  {
+    id: 'ele_tormenta',
+    name: 'Tormenta Estática',
+    archetype: 'electrico',
+    type: 'active',
+    cooldown: 4,
+    target: 'single',
+    effect: { damage: 1.3, stunChance: 0.30 },
+  },
+  {
+    id: 'ele_pulso',
+    name: 'Pulso EMP',
+    archetype: 'electrico',
+    type: 'active',
+    cooldown: 5,
+    target: 'single',
+    effect: { debuff: { stat: 'damage', pct: 0.30, turns: 2 } },
+  },
+
+  // Pasivas
+  {
     id: 'ele_cond',
     name: 'Conductividad',
     archetype: 'electrico',
@@ -106,8 +209,30 @@ export const ABILITIES: Ability[] = [
     target: 'self',
     effect: { tiebreaker: true },
   },
+  {
+    id: 'ele_estatica',
+    name: 'Carga Estática',
+    archetype: 'electrico',
+    type: 'passive',
+    cooldown: 0,
+    target: 'self',
+    effect: { critBoost: 0.15 },
+  },
+  {
+    id: 'ele_blindaje',
+    name: 'Blindaje Eléctrico',
+    archetype: 'electrico',
+    type: 'passive',
+    cooldown: 0,
+    target: 'self',
+    effect: { immunity: 'stun' },
+  },
 
-  // ── 💧 Acuático ───────────────────────────────────────────────────────────────
+  // ════════════════════════════════════════════════════════════════════════════
+  // 💧 ACUÁTICO — 6 activas + 3 pasivas
+  // ════════════════════════════════════════════════════════════════════════════
+
+  // Activas
   {
     id: 'acu_marea',
     name: 'Marea Curativa',
@@ -118,14 +243,54 @@ export const ABILITIES: Ability[] = [
     effect: { heal: 1.0 },
   },
   {
-    id: 'acu_tsun',
-    name: 'Tsunami',
+    id: 'acu_corriente',
+    name: 'Corriente Gélida',
+    archetype: 'acuatico',
+    type: 'active',
+    cooldown: 4,
+    target: 'single',
+    effect: { damage: 1.2, debuff: { stat: 'agility', pct: 0.20, turns: 2 } },
+  },
+  {
+    id: 'acu_burbuja',
+    name: 'Burbuja Escudo',
     archetype: 'acuatico',
     type: 'active',
     cooldown: 5,
-    target: 'all',
-    effect: { damage: 0.6 },
+    target: 'self',
+    effect: { shield: 80 },
   },
+  {
+    id: 'acu_helar',
+    name: 'Congelamiento',
+    archetype: 'acuatico',
+    type: 'active',
+    cooldown: 6,
+    target: 'single',
+    effect: {
+      debuff: { stat: 'agility', pct: 0.50, turns: 2 },
+    },
+  },
+  {
+    id: 'acu_absorber',
+    name: 'Absorber',
+    archetype: 'acuatico',
+    type: 'active',
+    cooldown: 5,
+    target: 'self',
+    effect: { heal: 1.4 },
+  },
+  {
+    id: 'acu_presion',
+    name: 'Presión Hidráulica',
+    archetype: 'acuatico',
+    type: 'active',
+    cooldown: 3,
+    target: 'single',
+    effect: { damage: 1.1, debuff: { stat: 'damage', pct: 0.10, turns: 2 } },
+  },
+
+  // Pasivas
   {
     id: 'acu_fluid',
     name: 'Fluidez',
@@ -135,26 +300,86 @@ export const ABILITIES: Ability[] = [
     target: 'self',
     effect: { damageReduction: 0.15 },
   },
-
-  // ── 🔥 Volcánico ──────────────────────────────────────────────────────────────
   {
-    id: 'vol_erup',
-    name: 'Erupción',
-    archetype: 'volcanico',
-    type: 'active',
-    cooldown: 4,
-    target: 'all',
-    effect: { damage: 0.6 },
+    id: 'acu_escama',
+    name: 'Escamas de Hielo',
+    archetype: 'acuatico',
+    type: 'passive',
+    cooldown: 0,
+    target: 'self',
+    effect: { thorns: 0.10 },
   },
+  {
+    id: 'acu_corrientevida',
+    name: 'Corriente de Vida',
+    archetype: 'acuatico',
+    type: 'passive',
+    cooldown: 0,
+    target: 'self',
+    effect: { regen: 12 },
+  },
+
+  // ════════════════════════════════════════════════════════════════════════════
+  // 🔥 VOLCÁNICO — 6 activas + 3 pasivas
+  // ════════════════════════════════════════════════════════════════════════════
+
+  // Activas
   {
     id: 'vol_intim',
     name: 'Intimidar',
     archetype: 'volcanico',
     type: 'active',
     cooldown: 4,
-    target: 'all',
-    effect: { debuff: { stat: 'damage', pct: -0.20, turns: 2 } },
+    target: 'single',
+    effect: { debuff: { stat: 'damage', pct: 0.20, turns: 2 } },
   },
+  {
+    id: 'vol_ejecucion',
+    name: 'Ejecución Ígnea',
+    archetype: 'volcanico',
+    type: 'active',
+    cooldown: 5,
+    target: 'single',
+    effect: { damage: 1.0, execute: { threshold: 0.35, bonus: 2.0 } },
+  },
+  {
+    id: 'vol_golpe',
+    name: 'Golpe Magmático',
+    archetype: 'volcanico',
+    type: 'active',
+    cooldown: 4,
+    target: 'single',
+    effect: { damage: 1.6 },
+  },
+  {
+    id: 'vol_quemadura',
+    name: 'Quemadura Profunda',
+    archetype: 'volcanico',
+    type: 'active',
+    cooldown: 4,
+    target: 'single',
+    effect: { damage: 0.8, dot: { damage: 0.4, turns: 3 } },
+  },
+  {
+    id: 'vol_explosion',
+    name: 'Explosión Controlada',
+    archetype: 'volcanico',
+    type: 'active',
+    cooldown: 3,
+    target: 'single',
+    effect: { damage: 1.3 },
+  },
+  {
+    id: 'vol_lava',
+    name: 'Lluvia de Lava',
+    archetype: 'volcanico',
+    type: 'active',
+    cooldown: 5,
+    target: 'single',
+    effect: { damage: 0.9, debuff: { stat: 'damage', pct: 0.25, turns: 2 } },
+  },
+
+  // Pasivas
   {
     id: 'vol_aura',
     name: 'Aura Ígnea',
@@ -162,17 +387,49 @@ export const ABILITIES: Ability[] = [
     type: 'passive',
     cooldown: 0,
     target: 'self',
-    effect: { reflect: 0.20 },
+    effect: { thorns: 0.20 },
+  },
+  {
+    id: 'vol_berserker',
+    name: 'Berserker',
+    archetype: 'volcanico',
+    type: 'passive',
+    cooldown: 0,
+    target: 'self',
+    effect: { critBoost: 0.20 },
+  },
+  {
+    id: 'vol_nucleo',
+    name: 'Núcleo Ardiente',
+    archetype: 'volcanico',
+    type: 'passive',
+    cooldown: 0,
+    target: 'self',
+    effect: { immunity: 'debuff' },
   },
 ]
 
-// ─── Lookups ──────────────────────────────────────────────────────────────────
+// ─── Índices derivados ────────────────────────────────────────────────────────
 
-const ALL_ABILITIES = [...INNATE_ABILITIES, ...ABILITIES]
+export const ALL_ABILITIES: Ability[] = [...INNATE_ABILITIES, ...ABILITIES]
+
 export const ABILITY_BY_ID: Record<string, Ability> = Object.fromEntries(
   ALL_ABILITIES.map(a => [a.id, a])
 )
 
-export const INNATE_BY_ARCHETYPE: Record<string, Ability> = Object.fromEntries(
-  INNATE_ABILITIES.map(a => [a.archetype, a])
-)
+export const INNATE_BY_ARCHETYPE: Record<Archetype, Ability> = {
+  forestal:  INNATE_ABILITIES[0],
+  electrico: INNATE_ABILITIES[1],
+  acuatico:  INNATE_ABILITIES[2],
+  volcanico: INNATE_ABILITIES[3],
+}
+
+/** Habilidades activas equipables por arquetipo */
+export function getActiveAbilities(archetype: Archetype): Ability[] {
+  return ABILITIES.filter(a => a.archetype === archetype && a.type === 'active')
+}
+
+/** Habilidades pasivas equipables por arquetipo */
+export function getPassiveAbilities(archetype: Archetype): Ability[] {
+  return ABILITIES.filter(a => a.archetype === archetype && a.type === 'passive')
+}

--- a/lib/pvp/energy.ts
+++ b/lib/pvp/energy.ts
@@ -1,0 +1,38 @@
+export const ENERGY_MAX = 10
+export const ENERGY_REGEN_MS = 160 * 60 * 1000 // 160 minutos
+
+export function computeEnergy(
+  pvpEnergy: number,
+  pvpEnergyRegenAt: Date | null,
+): { energy: number; regenAt: Date | null; dirty: boolean } {
+  if (pvpEnergy >= ENERGY_MAX || !pvpEnergyRegenAt) {
+    return { energy: Math.min(pvpEnergy, ENERGY_MAX), regenAt: null, dirty: false }
+  }
+
+  const now = Date.now()
+  let energy = pvpEnergy
+  let regenAt: Date | null = pvpEnergyRegenAt
+  let dirty = false
+
+  while (regenAt && regenAt.getTime() <= now && energy < ENERGY_MAX) {
+    energy += 1
+    dirty = true
+    if (energy >= ENERGY_MAX) {
+      regenAt = null
+      break
+    }
+    regenAt = new Date(regenAt.getTime() + ENERGY_REGEN_MS)
+  }
+
+  return { energy, regenAt, dirty }
+}
+
+export function spendEnergy(
+  pvpEnergy: number,
+  pvpEnergyRegenAt: Date | null,
+): { energy: number; regenAt: Date } {
+  if (pvpEnergy <= 0) throw new Error('NO_ENERGY')
+  const newEnergy = pvpEnergy - 1
+  const newRegenAt = pvpEnergyRegenAt ?? new Date(Date.now() + ENERGY_REGEN_MS)
+  return { energy: newEnergy, regenAt: newRegenAt }
+}

--- a/lib/pvp/mmr.ts
+++ b/lib/pvp/mmr.ts
@@ -1,0 +1,96 @@
+export const MMR_GAIN = 25
+export const MMR_LOSS = 15
+export const MMR_FLOOR = 0
+
+export const WEEKLY_WINS_REQUIRED = 15
+export const WEEKLY_CHEST_GOLD = 800
+export const WEEKLY_CHEST_EGG = 'egg_uncommon'
+export const WEEKLY_CHEST_RUNE_POOL = ['rune_vit_t1', 'rune_agi_t1', 'rune_ins_t1', 'rune_cha_t1']
+export const WEEKLY_CHEST_RUNE_COUNT = 2
+
+export type Rank = 'HIERRO' | 'BRONCE' | 'PLATA' | 'ORO' | 'PLATINO' | 'MITICO'
+
+export interface MonthlyReward {
+  gold: number
+  essence: number
+  eggs: string[]
+  accessories: string[]
+  runes: string[]
+}
+
+export function getRankFromMmr(mmr: number): Rank {
+  if (mmr >= 2600) return 'MITICO'
+  if (mmr >= 2200) return 'PLATINO'
+  if (mmr >= 1800) return 'ORO'
+  if (mmr >= 1400) return 'PLATA'
+  if (mmr >= 1000) return 'BRONCE'
+  return 'HIERRO'
+}
+
+export function getGoldRewardByRank(rank: Rank): number {
+  if (rank === 'PLATINO' || rank === 'MITICO') return 100
+  if (rank === 'PLATA' || rank === 'ORO') return 75
+  return 50 // HIERRO, BRONCE
+}
+
+export function applyMmrChange(currentMmr: number, won: boolean): { newMmr: number; delta: number } {
+  const delta = won ? MMR_GAIN : -MMR_LOSS
+  const newMmr = Math.max(MMR_FLOOR, currentMmr + delta)
+  return { newMmr, delta: newMmr - currentMmr }
+}
+
+export function needsWeeklyReset(resetAt: Date | null): boolean {
+  if (!resetAt) return true
+  const WEEK_MS = 7 * 24 * 60 * 60 * 1000
+  return Date.now() - resetAt.getTime() > WEEK_MS
+}
+
+export function currentMonthKey(): string {
+  const now = new Date()
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+}
+
+/** Pick `count` random elements from an array without repeating. */
+export function pickRandom<T>(arr: T[], count: number): T[] {
+  const shuffled = [...arr].sort(() => Math.random() - 0.5)
+  return shuffled.slice(0, count)
+}
+
+export const MONTHLY_REWARDS: Record<Rank, MonthlyReward | null> = {
+  HIERRO: null,
+  BRONCE: {
+    gold: 1500,
+    essence: 1,
+    eggs: ['egg_uncommon'],
+    accessories: [],
+    runes: ['rune_vit_t1', 'rune_agi_t1'],
+  },
+  PLATA: {
+    gold: 3000,
+    essence: 3,
+    eggs: ['egg_rare'],
+    accessories: ['acc_glasses'],
+    runes: ['rune_vit_t1', 'rune_agi_t1', 'rune_ins_t1'],
+  },
+  ORO: {
+    gold: 6000,
+    essence: 7,
+    eggs: ['egg_epic'],
+    accessories: ['acc_tail_wolf'],
+    runes: ['rune_vit_t2', 'rune_agi_t2', 'rune_all_t1'],
+  },
+  PLATINO: {
+    gold: 12000,
+    essence: 15,
+    eggs: ['egg_legendary'],
+    accessories: ['acc_ears_wolf'],
+    runes: ['rune_vit_t3', 'rune_agi_t3', 'rune_ins_t3', 'rune_all_t2', 'rune_cha_t2'],
+  },
+  MITICO: {
+    gold: 30000,
+    essence: 30,
+    eggs: ['egg_legendary'],
+    accessories: ['acc_crown'],
+    runes: ['rune_vit_t4', 'rune_agi_t4', 'rune_all_t3', 'rune_all_t3', 'rune_cha_t4'],
+  },
+}

--- a/lib/shop/catalog.ts
+++ b/lib/shop/catalog.ts
@@ -1,4 +1,4 @@
-export type ShopItemType = 'cosmetic' | 'service' | 'slot' | 'rune'
+export type ShopItemType = 'cosmetic' | 'service' | 'slot' | 'rune' | 'ability'
 
 export interface ShopItem {
   id: string
@@ -11,6 +11,9 @@ export interface ShopItem {
   accessoryId?: string
   slot?: string // accessory slot ID (orejas | cola | ojos | cabeza | anteojos | garras)
   runeId?: string
+  abilityId?: string
+  abilityType?: 'active' | 'passive'
+  archetype?: string
   tier?: 1 | 2 | 3 | 4 | 5
 }
 
@@ -108,6 +111,58 @@ export const SHOP_ITEMS: ShopItem[] = [
   { id: 'rune_ins_t3', name: 'Runa de Instinto III',  emoji: '🌌', description: '+3 Instinto. Nada escapa a tu atención.',                costGold: 0, costCoin: 50, type: 'rune', runeId: 'rune_ins_t3', tier: 3 },
   { id: 'rune_cha_t3', name: 'Runa de Carisma III',   emoji: '✨', description: '+3 Carisma. Convences sin esfuerzo.',                   costGold: 0, costCoin: 50, type: 'rune', runeId: 'rune_cha_t3', tier: 3 },
   { id: 'rune_all_t3', name: 'Runa de Equilibrio III',emoji: '🔮', description: '+3 a todos los stats. La unión de todas las fuerzas.',  costGold: 0, costCoin: 150, type: 'rune', runeId: 'rune_all_t3', tier: 3 },
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 🌿 HABILIDADES FORESTAL
+  // ══════════════════════════════════════════════════════════════════════════
+  { id: 'ab_for_regen',       name: 'Regeneración',        emoji: '🌿', description: 'Se cura a sí mismo con energía forestal.',             costGold: 300, costCoin: 0, type: 'ability', abilityId: 'for_regen',      abilityType: 'active',  archetype: 'forestal' },
+  { id: 'ab_for_enred',       name: 'Enredadera',          emoji: '🌿', description: 'Reduce la agilidad del rival con raíces.',             costGold: 400, costCoin: 0, type: 'ability', abilityId: 'for_enred',      abilityType: 'active',  archetype: 'forestal' },
+  { id: 'ab_for_latigo',      name: 'Látigo de Raíz',      emoji: '🌿', description: 'Golpe potente con raíces endurecidas.',                costGold: 400, costCoin: 0, type: 'ability', abilityId: 'for_latigo',     abilityType: 'active',  archetype: 'forestal' },
+  { id: 'ab_for_cura_salvaje',name: 'Cura Salvaje',        emoji: '🌿', description: 'Curación poderosa de energía silvestre.',              costGold: 350, costCoin: 0, type: 'ability', abilityId: 'for_cura_salvaje',abilityType: 'active', archetype: 'forestal' },
+  { id: 'ab_for_veneno',      name: 'Mordedura Venenosa',  emoji: '🌿', description: 'Daño inicial + veneno que dura varios turnos.',        costGold: 500, costCoin: 0, type: 'ability', abilityId: 'for_veneno',     abilityType: 'active',  archetype: 'forestal' },
+  { id: 'ab_for_drenar',      name: 'Drenar Vida',         emoji: '🌿', description: 'Roba vida del rival con cada golpe.',                  costGold: 600, costCoin: 0, type: 'ability', abilityId: 'for_drenar',     abilityType: 'active',  archetype: 'forestal' },
+  { id: 'ab_for_espinas',     name: 'Espinas',             emoji: '🌿', description: 'Refleja parte del daño recibido al atacante.',         costGold: 700, costCoin: 0, type: 'ability', abilityId: 'for_espinas',    abilityType: 'passive', archetype: 'forestal' },
+  { id: 'ab_for_raices',      name: 'Raíces Profundas',    emoji: '🌿', description: 'Se regenera HP al inicio de cada turno.',             costGold: 600, costCoin: 0, type: 'ability', abilityId: 'for_raices',     abilityType: 'passive', archetype: 'forestal' },
+  { id: 'ab_for_resiliencia', name: 'Resiliencia',         emoji: '🌿', description: 'Sobrevive una vez a un golpe fatal con 1 HP.',        costGold: 1000, costCoin: 0, type: 'ability', abilityId: 'for_resiliencia',abilityType: 'passive', archetype: 'forestal' },
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // ⚡ HABILIDADES ELÉCTRICO
+  // ══════════════════════════════════════════════════════════════════════════
+  { id: 'ab_ele_rayo',          name: 'Rayo Paralizante',  emoji: '⚡', description: 'Golpe eléctrico que aturde al rival un turno.',       costGold: 600, costCoin: 0, type: 'ability', abilityId: 'ele_rayo',         abilityType: 'active',  archetype: 'electrico' },
+  { id: 'ab_ele_sobre',         name: 'Sobrecarga',        emoji: '⚡', description: 'Aumenta la propia agilidad temporalmente.',           costGold: 400, costCoin: 0, type: 'ability', abilityId: 'ele_sobre',        abilityType: 'active',  archetype: 'electrico' },
+  { id: 'ab_ele_multirayo',     name: 'Multirayo',         emoji: '⚡', description: 'Tres descargas rápidas en un mismo turno.',           costGold: 500, costCoin: 0, type: 'ability', abilityId: 'ele_multirayo',    abilityType: 'active',  archetype: 'electrico' },
+  { id: 'ab_ele_cortocircuito', name: 'Cortocircuito',     emoji: '⚡', description: 'Reduce drásticamente la agilidad del rival.',        costGold: 500, costCoin: 0, type: 'ability', abilityId: 'ele_cortocircuito',abilityType: 'active',  archetype: 'electrico' },
+  { id: 'ab_ele_tormenta',      name: 'Tormenta Estática', emoji: '⚡', description: 'Golpe fuerte con probabilidad de aturdir.',           costGold: 500, costCoin: 0, type: 'ability', abilityId: 'ele_tormenta',     abilityType: 'active',  archetype: 'electrico' },
+  { id: 'ab_ele_pulso',         name: 'Pulso EMP',         emoji: '⚡', description: 'Reduce el daño del rival durante dos turnos.',        costGold: 500, costCoin: 0, type: 'ability', abilityId: 'ele_pulso',        abilityType: 'active',  archetype: 'electrico' },
+  { id: 'ab_ele_cond',          name: 'Conductividad',     emoji: '⚡', description: 'Actúa primero en empates de agilidad.',               costGold: 800, costCoin: 0, type: 'ability', abilityId: 'ele_cond',         abilityType: 'passive', archetype: 'electrico' },
+  { id: 'ab_ele_estatica',      name: 'Carga Estática',    emoji: '⚡', description: 'Aumenta la probabilidad de crítico.',                 costGold: 700, costCoin: 0, type: 'ability', abilityId: 'ele_estatica',     abilityType: 'passive', archetype: 'electrico' },
+  { id: 'ab_ele_blindaje',      name: 'Blindaje Eléctrico',emoji: '⚡', description: 'Inmune a efectos de aturdimiento.',                  costGold: 900, costCoin: 0, type: 'ability', abilityId: 'ele_blindaje',     abilityType: 'passive', archetype: 'electrico' },
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 💧 HABILIDADES ACUÁTICO
+  // ══════════════════════════════════════════════════════════════════════════
+  { id: 'ab_acu_marea',          name: 'Marea Curativa',    emoji: '💧', description: 'Cura a un aliado con energía del agua.',             costGold: 400, costCoin: 0, type: 'ability', abilityId: 'acu_marea',         abilityType: 'active',  archetype: 'acuatico' },
+  { id: 'ab_acu_corriente',      name: 'Corriente Gélida',  emoji: '💧', description: 'Golpe de agua que ralentiza al rival.',             costGold: 500, costCoin: 0, type: 'ability', abilityId: 'acu_corriente',     abilityType: 'active',  archetype: 'acuatico' },
+  { id: 'ab_acu_burbuja',        name: 'Burbuja Escudo',    emoji: '💧', description: 'Crea un escudo de agua que absorbe daño.',          costGold: 500, costCoin: 0, type: 'ability', abilityId: 'acu_burbuja',       abilityType: 'active',  archetype: 'acuatico' },
+  { id: 'ab_acu_helar',          name: 'Congelamiento',     emoji: '💧', description: 'Congela al rival, reduciendo drásticamente su agi.',costGold: 700, costCoin: 0, type: 'ability', abilityId: 'acu_helar',         abilityType: 'active',  archetype: 'acuatico' },
+  { id: 'ab_acu_absorber',       name: 'Absorber',          emoji: '💧', description: 'Curación poderosa de energía acuática.',            costGold: 600, costCoin: 0, type: 'ability', abilityId: 'acu_absorber',      abilityType: 'active',  archetype: 'acuatico' },
+  { id: 'ab_acu_presion',        name: 'Presión Hidráulica',emoji: '💧', description: 'Golpe que reduce el daño del rival progresivamente.',costGold: 400, costCoin: 0, type: 'ability', abilityId: 'acu_presion',       abilityType: 'active',  archetype: 'acuatico' },
+  { id: 'ab_acu_fluid',          name: 'Fluidez',           emoji: '💧', description: 'Reduce el daño entrante en un 15%.',                costGold: 800, costCoin: 0, type: 'ability', abilityId: 'acu_fluid',         abilityType: 'passive', archetype: 'acuatico' },
+  { id: 'ab_acu_escama',         name: 'Escamas de Hielo',  emoji: '💧', description: 'Devuelve parte del daño recibido.',                 costGold: 600, costCoin: 0, type: 'ability', abilityId: 'acu_escama',        abilityType: 'passive', archetype: 'acuatico' },
+  { id: 'ab_acu_corrientevida',  name: 'Corriente de Vida', emoji: '💧', description: 'Regenera HP al inicio de cada turno.',             costGold: 700, costCoin: 0, type: 'ability', abilityId: 'acu_corrientevida', abilityType: 'passive', archetype: 'acuatico' },
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // 🔥 HABILIDADES VOLCÁNICO
+  // ══════════════════════════════════════════════════════════════════════════
+  { id: 'ab_vol_intim',     name: 'Intimidar',           emoji: '🔥', description: 'Reduce el daño del rival con presencia ígnea.',       costGold: 400, costCoin: 0, type: 'ability', abilityId: 'vol_intim',    abilityType: 'active',  archetype: 'volcanico' },
+  { id: 'ab_vol_ejecucion', name: 'Ejecución Ígnea',     emoji: '🔥', description: 'Golpe letal con daño ×2 si el rival tiene poca vida.',costGold: 1000, costCoin: 0, type: 'ability', abilityId: 'vol_ejecucion',abilityType: 'active',  archetype: 'volcanico' },
+  { id: 'ab_vol_golpe',     name: 'Golpe Magmático',     emoji: '🔥', description: 'Golpe volcánico de alta potencia.',                  costGold: 600, costCoin: 0, type: 'ability', abilityId: 'vol_golpe',    abilityType: 'active',  archetype: 'volcanico' },
+  { id: 'ab_vol_quemadura', name: 'Quemadura Profunda',  emoji: '🔥', description: 'Inflama al rival, causando daño por varios turnos.', costGold: 500, costCoin: 0, type: 'ability', abilityId: 'vol_quemadura',abilityType: 'active',  archetype: 'volcanico' },
+  { id: 'ab_vol_explosion', name: 'Explosión Controlada',emoji: '🔥', description: 'Explosión rápida de daño volcánico.',                costGold: 400, costCoin: 0, type: 'ability', abilityId: 'vol_explosion',abilityType: 'active',  archetype: 'volcanico' },
+  { id: 'ab_vol_lava',      name: 'Lluvia de Lava',      emoji: '🔥', description: 'Golpe que también debilita el daño del rival.',       costGold: 500, costCoin: 0, type: 'ability', abilityId: 'vol_lava',     abilityType: 'active',  archetype: 'volcanico' },
+  { id: 'ab_vol_aura',      name: 'Aura Ígnea',          emoji: '🔥', description: 'Aura ardiente que daña a quien te ataque.',          costGold: 800, costCoin: 0, type: 'ability', abilityId: 'vol_aura',     abilityType: 'passive', archetype: 'volcanico' },
+  { id: 'ab_vol_berserker', name: 'Berserker',           emoji: '🔥', description: 'Aumenta la probabilidad de golpe crítico.',          costGold: 700, costCoin: 0, type: 'ability', abilityId: 'vol_berserker',abilityType: 'passive', archetype: 'volcanico' },
+  { id: 'ab_vol_nucleo',    name: 'Núcleo Ardiente',     emoji: '🔥', description: 'Inmune a efectos de debilitamiento.',                costGold: 1000, costCoin: 0, type: 'ability', abilityId: 'vol_nucleo',   abilityType: 'passive', archetype: 'volcanico' },
 ]
 
 export function getShopItem(id: string): ShopItem | undefined {

--- a/lib/therian-dto.ts
+++ b/lib/therian-dto.ts
@@ -4,9 +4,26 @@ import { getTraitById } from './catalogs/traits'
 import { getPaletteById } from './catalogs/appearance'
 import { getRuneById, type Rune } from './catalogs/runes'
 import { getAuraById, TIER_LABEL } from './catalogs/auras'
-import type { TherianStats, TherianAppearance, Rarity } from './generation/engine'
+import type { TherianStats, TherianAppearance, Rarity, Archetype } from './generation/engine'
 import { SHOP_ITEMS } from './shop/catalog'
 import { MAX_ACTIONS } from './actions/narratives'
+
+const LEGACY_ARCHETYPE_MAP: Record<string, Archetype> = {
+  silent:      'forestal',
+  mystic:      'forestal',
+  guardian:    'acuatico',
+  curious:     'acuatico',
+  impulsive:   'electrico',
+  feral:       'electrico',
+  charismatic: 'volcanico',
+  loyal:       'volcanico',
+}
+const VALID_ARCHETYPES: Archetype[] = ['forestal', 'electrico', 'acuatico', 'volcanico']
+
+function resolveArchetype(traitId: string): Archetype {
+  if ((VALID_ARCHETYPES as string[]).includes(traitId)) return traitId as Archetype
+  return LEGACY_ARCHETYPE_MAP[traitId] ?? 'forestal'
+}
 
 function parseEquippedAccessories(raw: string | null): Record<string, string> {
   try {
@@ -88,6 +105,7 @@ export function toTherianDTO(therian: Therian) {
     trait: trait
       ? { id: trait.id, name: trait.name, lore: trait.lore }
       : { id: therian.traitId, name: therian.traitId, lore: '' },
+    archetype: resolveArchetype(therian.traitId),
     appearance: {
       palette: appearance.palette,
       paletteColors: palette
@@ -111,6 +129,7 @@ export function toTherianDTO(therian: Therian) {
     nextBiteAt,
     equippedAccessories: parseEquippedAccessories(therian.accessories ?? null),
     equippedAbilities: JSON.parse(therian.equippedAbilities || '[]') as string[],
+    equippedPassives:  JSON.parse((therian as any).equippedPassives || '[]') as string[],
     aura: (() => {
       const auraId = (therian as any).auraId as string | null | undefined
       if (!auraId) return null

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "db:down": "docker compose down",
     "db:migrate": "dotenv -e .env -- prisma migrate deploy",
     "db:studio": "dotenv -e .env -- prisma studio",
-    "db:migrate:prod": "dotenv -e .env.migrate -- prisma migrate deploy"
+    "db:migrate:prod": "dotenv -e .env.migrate -- prisma migrate deploy",
+    "test:pvp": "npx tsx lib/pvp/__test__/pvp-full.test.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",

--- a/prisma/migrations/20260228000000_pvp_user_fields/migration.sql
+++ b/prisma/migrations/20260228000000_pvp_user_fields/migration.sql
@@ -1,0 +1,27 @@
+-- Add PvP-related fields to User table
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "tutorialProgress"      TEXT NOT NULL DEFAULT '{}';
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "mmr"                   INTEGER NOT NULL DEFAULT 1000;
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "peakMmr"               INTEGER NOT NULL DEFAULT 1000;
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "weeklyPvpWins"         INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "weeklyPvpResetAt"      TIMESTAMP(3);
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "lastWeeklyChestAt"     TIMESTAMP(3);
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "lastMonthlyRewardMonth" TEXT;
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "pvpEnergy"             INTEGER NOT NULL DEFAULT 10;
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "pvpEnergyRegenAt"      TIMESTAMP(3);
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "savedPvpTeam"          TEXT;
+
+-- CreateTable: UserRuneInventory (runes awarded via PvP rewards, not tied to a specific Therian)
+CREATE TABLE IF NOT EXISTS "UserRuneInventory" (
+    "id"       TEXT NOT NULL,
+    "userId"   TEXT NOT NULL,
+    "runeId"   TEXT NOT NULL,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "source"   TEXT NOT NULL DEFAULT 'reward',
+
+    CONSTRAINT "UserRuneInventory_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "UserRuneInventory_userId_runeId_key" UNIQUE ("userId", "runeId")
+);
+
+-- AddForeignKey
+ALTER TABLE "UserRuneInventory" ADD CONSTRAINT "UserRuneInventory_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260302000000_ability_inventory/migration.sql
+++ b/prisma/migrations/20260302000000_ability_inventory/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable UserAbilityInventory
+CREATE TABLE IF NOT EXISTS "UserAbilityInventory" (
+  "id"         TEXT NOT NULL,
+  "userId"     TEXT NOT NULL,
+  "abilityId"  TEXT NOT NULL,
+  "quantity"   INTEGER NOT NULL DEFAULT 1,
+  "obtainedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "UserAbilityInventory_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "UserAbilityInventory_userId_abilityId_key" UNIQUE ("userId", "abilityId"),
+  CONSTRAINT "UserAbilityInventory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- AlterTable Therian: add equippedPassives
+ALTER TABLE "Therian" ADD COLUMN IF NOT EXISTS "equippedPassives" TEXT NOT NULL DEFAULT '[]';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,7 @@ model User {
   verificationTokens VerificationToken[]
   inventoryItems     InventoryItem[]
   userRuneInventory  UserRuneInventory[]
+  abilityInventory   UserAbilityInventory[]
 }
 
 model VerificationToken {
@@ -75,7 +76,8 @@ model Therian {
   lastBiteAt  DateTime?
   accessories       String    @default("[]") @db.Text
   status            String    @default("active") // "active" | "capsule"
-  equippedAbilities String    @default("[]") @db.Text // JSON: string[] ability IDs, max 4
+  equippedAbilities String    @default("[]") @db.Text // JSON: active ability IDs, max 3
+  equippedPassives  String    @default("[]") @db.Text // JSON: passive ability IDs, max 2
   auraId            String?   // ID from lib/catalogs/auras.ts (assigned at generation)
 
   battlesAsChallenger BattleLog[] @relation("Challenger")
@@ -138,6 +140,17 @@ model UserRuneInventory {
   source   String   @default("reward") // "weekly" | "monthly" | "gift"
 
   @@unique([userId, runeId])
+}
+
+model UserAbilityInventory {
+  id         String   @id @default(uuid())
+  userId     String
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  abilityId  String
+  quantity   Int      @default(1)
+  obtainedAt DateTime @default(now())
+
+  @@unique([userId, abilityId])
 }
 
 model InventoryItem {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,9 +28,19 @@ model User {
   lastPassiveClaim      DateTime?
   completedCollections  String             @default("[]") @db.Text
   tutorialProgress      String             @default("{}") @db.Text
+  mmr                    Int               @default(1000)
+  peakMmr                Int               @default(1000)
+  weeklyPvpWins          Int               @default(0)
+  weeklyPvpResetAt       DateTime?
+  lastWeeklyChestAt      DateTime?
+  lastMonthlyRewardMonth String?
+  pvpEnergy              Int               @default(10)
+  pvpEnergyRegenAt       DateTime?
+  savedPvpTeam           String?
   therians           Therian[]
   verificationTokens VerificationToken[]
   inventoryItems     InventoryItem[]
+  userRuneInventory  UserRuneInventory[]
 }
 
 model VerificationToken {
@@ -117,6 +127,17 @@ model PvpBattle {
   winnerId     String?  // userId del ganador (null si ganó el defensor)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+}
+
+model UserRuneInventory {
+  id       String   @id @default(uuid())
+  userId   String
+  user     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  runeId   String
+  quantity Int      @default(1)
+  source   String   @default("reward") // "weekly" | "monthly" | "gift"
+
+  @@unique([userId, runeId])
 }
 
 model InventoryItem {

--- a/public/ranks/bronce.svg
+++ b/public/ranks/bronce.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 120">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#92400E"/>
+      <stop offset="100%" stop-color="#1C0700"/>
+    </linearGradient>
+  </defs>
+  <path d="M50 7 L92 26 L92 65 Q92 100 50 114 Q8 100 8 65 L8 26 Z" fill="url(#bg)" stroke="#D97706" stroke-width="2.5"/>
+  <path d="M50 13 L87 29 L87 65 Q87 97 50 109 Q13 97 13 65 L13 29 Z" fill="none" stroke="#FDE68A" stroke-width="0.75" opacity="0.2"/>
+  <text x="50" y="39" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="9" font-weight="900" fill="#FDE68A" letter-spacing="1">BRONCE</text>
+  <!-- Crossed swords -->
+  <line x1="29" y1="50" x2="71" y2="90" stroke="#D97706" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="71" y1="50" x2="29" y2="90" stroke="#D97706" stroke-width="3.5" stroke-linecap="round"/>
+  <!-- Sword tips (top points) -->
+  <circle cx="29" cy="50" r="2.5" fill="#F59E0B"/>
+  <circle cx="71" cy="50" r="2.5" fill="#F59E0B"/>
+  <!-- Sword hilts (horizontal crossguards) -->
+  <line x1="22" y1="58" x2="38" y2="56" stroke="#FDE68A" stroke-width="3" stroke-linecap="round"/>
+  <line x1="62" y1="56" x2="78" y2="58" stroke="#FDE68A" stroke-width="3" stroke-linecap="round"/>
+  <!-- Center gem -->
+  <circle cx="50" cy="70" r="5" fill="#92400E" stroke="#F59E0B" stroke-width="2"/>
+  <circle cx="50" cy="70" r="2.2" fill="#FDE68A"/>
+</svg>

--- a/public/ranks/hierro.svg
+++ b/public/ranks/hierro.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 120">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6B7280"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+  </defs>
+  <path d="M50 7 L92 26 L92 65 Q92 100 50 114 Q8 100 8 65 L8 26 Z" fill="url(#bg)" stroke="#9CA3AF" stroke-width="2.5"/>
+  <path d="M50 13 L87 29 L87 65 Q87 97 50 109 Q13 97 13 65 L13 29 Z" fill="none" stroke="#E5E7EB" stroke-width="0.75" opacity="0.2"/>
+  <text x="50" y="39" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="9" font-weight="900" fill="#E5E7EB" letter-spacing="1.5">HIERRO</text>
+  <!-- Gear centered at (50, 72) -->
+  <g transform="translate(50,72)">
+    <rect x="-2.4" y="-17" width="4.8" height="6" rx="1.5" fill="#9CA3AF"/>
+    <rect x="-2.4" y="-17" width="4.8" height="6" rx="1.5" fill="#9CA3AF" transform="rotate(45)"/>
+    <rect x="-2.4" y="-17" width="4.8" height="6" rx="1.5" fill="#9CA3AF" transform="rotate(90)"/>
+    <rect x="-2.4" y="-17" width="4.8" height="6" rx="1.5" fill="#9CA3AF" transform="rotate(135)"/>
+    <rect x="-2.4" y="-17" width="4.8" height="6" rx="1.5" fill="#9CA3AF" transform="rotate(180)"/>
+    <rect x="-2.4" y="-17" width="4.8" height="6" rx="1.5" fill="#9CA3AF" transform="rotate(225)"/>
+    <rect x="-2.4" y="-17" width="4.8" height="6" rx="1.5" fill="#9CA3AF" transform="rotate(270)"/>
+    <rect x="-2.4" y="-17" width="4.8" height="6" rx="1.5" fill="#9CA3AF" transform="rotate(315)"/>
+    <circle r="11" fill="#374151" stroke="#9CA3AF" stroke-width="2"/>
+    <circle r="4" fill="#1F2937" stroke="#9CA3AF" stroke-width="1.5"/>
+    <circle r="1.8" fill="#9CA3AF"/>
+  </g>
+</svg>

--- a/public/ranks/mitico.svg
+++ b/public/ranks/mitico.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 120">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7C3AED"/>
+      <stop offset="100%" stop-color="#1E0A45"/>
+    </linearGradient>
+    <linearGradient id="star" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#DDD6FE"/>
+      <stop offset="100%" stop-color="#8B5CF6"/>
+    </linearGradient>
+  </defs>
+  <path d="M50 7 L92 26 L92 65 Q92 100 50 114 Q8 100 8 65 L8 26 Z" fill="url(#bg)" stroke="#A78BFA" stroke-width="2.5"/>
+  <path d="M50 13 L87 29 L87 65 Q87 97 50 109 Q13 97 13 65 L13 29 Z" fill="none" stroke="#EDE9FE" stroke-width="0.75" opacity="0.25"/>
+  <text x="50" y="39" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="9" font-weight="900" fill="#EDE9FE" letter-spacing="1">MÍTICO</text>
+  <!-- 8-pointed starburst centered at (50,68), outer r=18, inner r=8 -->
+  <!-- Outer: 50,50  62.7,55.3  68,68  62.7,80.7  50,86  37.3,80.7  32,68  37.3,55.3 -->
+  <!-- Inner: 53.1,60.6  57.4,64.9  57.4,71.1  53.1,75.4  46.9,75.4  42.6,71.1  42.6,64.9  46.9,60.6 -->
+  <polygon
+    points="50,50 53.1,60.6 62.7,55.3 57.4,64.9 68,68 57.4,71.1 62.7,80.7 53.1,75.4 50,86 46.9,75.4 37.3,80.7 42.6,71.1 32,68 42.6,64.9 37.3,55.3 46.9,60.6"
+    fill="url(#star)" stroke="#A78BFA" stroke-width="1.5"/>
+  <!-- Center circle -->
+  <circle cx="50" cy="68" r="6" fill="#4C1D95" stroke="#A78BFA" stroke-width="1.5"/>
+  <circle cx="50" cy="68" r="3" fill="#EDE9FE" opacity="0.9"/>
+</svg>

--- a/public/ranks/oro.svg
+++ b/public/ranks/oro.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 120">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#B45309"/>
+      <stop offset="100%" stop-color="#1C0700"/>
+    </linearGradient>
+  </defs>
+  <path d="M50 7 L92 26 L92 65 Q92 100 50 114 Q8 100 8 65 L8 26 Z" fill="url(#bg)" stroke="#F59E0B" stroke-width="2.5"/>
+  <path d="M50 13 L87 29 L87 65 Q87 97 50 109 Q13 97 13 65 L13 29 Z" fill="none" stroke="#FDE68A" stroke-width="0.75" opacity="0.25"/>
+  <text x="50" y="39" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="9" font-weight="900" fill="#FDE68A" letter-spacing="3">ORO</text>
+  <!-- Crown shape: 3-tipped crown -->
+  <path d="M28 90 L72 90 L72 78 L65 60 L57 72 L50 53 L43 72 L35 60 L28 78 Z"
+        fill="#92400E" stroke="#F59E0B" stroke-width="2.5" stroke-linejoin="round"/>
+  <!-- Base highlight -->
+  <rect x="28" y="83" width="44" height="7" rx="1.5" fill="#78350F" stroke="#F59E0B" stroke-width="1.5"/>
+  <!-- Tip gems -->
+  <circle cx="50" cy="53" r="3.5" fill="#FDE68A" stroke="#F59E0B" stroke-width="1.5"/>
+  <circle cx="35" cy="60" r="3" fill="#FDE68A" stroke="#F59E0B" stroke-width="1.5"/>
+  <circle cx="65" cy="60" r="3" fill="#FDE68A" stroke="#F59E0B" stroke-width="1.5"/>
+  <!-- Base gems -->
+  <circle cx="50" cy="86.5" r="3" fill="#FBBF24"/>
+  <circle cx="38" cy="86.5" r="2.2" fill="#FBBF24"/>
+  <circle cx="62" cy="86.5" r="2.2" fill="#FBBF24"/>
+</svg>

--- a/public/ranks/plata.svg
+++ b/public/ranks/plata.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 120">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#64748B"/>
+      <stop offset="100%" stop-color="#0F172A"/>
+    </linearGradient>
+  </defs>
+  <path d="M50 7 L92 26 L92 65 Q92 100 50 114 Q8 100 8 65 L8 26 Z" fill="url(#bg)" stroke="#CBD5E1" stroke-width="2.5"/>
+  <path d="M50 13 L87 29 L87 65 Q87 97 50 109 Q13 97 13 65 L13 29 Z" fill="none" stroke="#E2E8F0" stroke-width="0.75" opacity="0.25"/>
+  <text x="50" y="39" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="9" font-weight="900" fill="#F1F5F9" letter-spacing="2">PLATA</text>
+  <!-- 5-pointed star centered at (50, 65), outer r=17, inner r=7 -->
+  <polygon
+    points="50,48 54.1,59.3 65.2,60.1 56.7,67.2 59.4,77.9 50,72 40.6,77.9 43.3,67.2 34.8,60.1 45.9,59.3"
+    fill="#94A3B8" stroke="#E2E8F0" stroke-width="1.5"/>
+  <!-- Star center shine -->
+  <circle cx="50" cy="65" r="3.5" fill="#F1F5F9" opacity="0.6"/>
+</svg>

--- a/public/ranks/platino.svg
+++ b/public/ranks/platino.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 120">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0E7490"/>
+      <stop offset="100%" stop-color="#042F2E"/>
+    </linearGradient>
+    <linearGradient id="gem" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#A5F3FC"/>
+      <stop offset="100%" stop-color="#0891B2"/>
+    </linearGradient>
+  </defs>
+  <path d="M50 7 L92 26 L92 65 Q92 100 50 114 Q8 100 8 65 L8 26 Z" fill="url(#bg)" stroke="#22D3EE" stroke-width="2.5"/>
+  <path d="M50 13 L87 29 L87 65 Q87 97 50 109 Q13 97 13 65 L13 29 Z" fill="none" stroke="#CFFAFE" stroke-width="0.75" opacity="0.25"/>
+  <text x="50" y="39" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="8.5" font-weight="900" fill="#CFFAFE" letter-spacing="0.8">PLATINO</text>
+  <!-- Diamond gem centered at (50,68): top(50,50) right(68,68) bottom(50,87) left(32,68) -->
+  <polygon points="50,50 68,68 50,87 32,68" fill="url(#gem)" stroke="#22D3EE" stroke-width="2.5"/>
+  <!-- Gem facet lines -->
+  <polyline points="50,50 57,61 50,87" fill="none" stroke="#CFFAFE" stroke-width="0.75" opacity="0.5"/>
+  <polyline points="50,50 43,61 50,87" fill="none" stroke="#CFFAFE" stroke-width="0.75" opacity="0.5"/>
+  <line x1="32" y1="68" x2="68" y2="68" stroke="#CFFAFE" stroke-width="0.75" opacity="0.4"/>
+  <!-- Top facet highlight -->
+  <polygon points="50,50 57,61 43,61" fill="#CFFAFE" opacity="0.3"/>
+  <!-- Center shine -->
+  <circle cx="50" cy="68" r="2.5" fill="#CFFAFE" opacity="0.8"/>
+</svg>


### PR DESCRIPTION
## Resumen

- **Libro de Hechizos** (`/spellbook`): página con catálogo de 36 habilidades, filtros por arquetipo/tipo, ownership con badge ×N y compra directa
- **Inventario de habilidades**: tabla `UserAbilityInventory`, API `GET /api/user/abilities`, panel en TherianCard con slots Activas (max 3) y Pasivas (max 2)
- **PvP modo manual**: endpoints `/turn` y `/switch-frontliner`, click en banco para cambiar frontliner con cooldown overlay, selector Auto/Manual en TeamSetup
- **Fix fusión**: resultado va a cápsula si no hay slots activos disponibles; aviso en FusionModal
- **Restricción huevos**: comprar huevo X requiere Therian de rareza X+1; tienda bloquea visualmente los que no cumplen requisito

## Test plan

- [ ] Verificar `/spellbook` carga con filtros funcionales y ownership correcto
- [ ] Comprar habilidad en spellbook/tienda → aparece en inventario
- [ ] Equipar activas/pasivas desde TherianCard, validar límites (3 activas, 2 pasivas)
- [ ] Batalla PvP modo manual: ejecutar turno con `/turn`, cambiar frontliner con click en banco
- [ ] Fusionar con slots llenos → Therian resultante en cápsula, banner ambar en modal
- [ ] Intentar comprar huevo épico sin Legendario → botón bloqueado en UI y 403 en API
- [ ] Migración `20260302000000_ability_inventory` desplegada sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)